### PR TITLE
config: add env var parsing

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -752,38 +752,45 @@ var (
 	}
 	// Flags associated with Layer 1 Transaction Ingestion
 	TxIngestionEnableFlag = cli.BoolFlag{
-		Name:  "txingestion.enable",
-		Usage: "Enable L1 Transaction Ingestion",
+		Name:   "txingestion.enable",
+		Usage:  "Enable L1 Transaction Ingestion",
+		EnvVar: "TX_INGESTION",
 	}
 	TxIngestionDBHostFlag = cli.StringFlag{
-		Name:  "txingestion.dbhost",
-		Usage: "HTTP host of SQL database to ingest transactions from",
-		Value: eth.DefaultConfig.Rollup.TxIngestionDBHost,
+		Name:   "txingestion.dbhost",
+		Usage:  "HTTP host of SQL database to ingest transactions from",
+		Value:  eth.DefaultConfig.Rollup.TxIngestionDBHost,
+		EnvVar: "TX_INGESTION_DB_HOST",
 	}
 	TxIngestionDBPortFlag = cli.IntFlag{
-		Name:  "txingestion.dbport",
-		Usage: "HTTP port of SQL database to ingest transactions from",
-		Value: int(eth.DefaultConfig.Rollup.TxIngestionDBPort),
+		Name:   "txingestion.dbport",
+		Usage:  "HTTP port of SQL database to ingest transactions from",
+		Value:  int(eth.DefaultConfig.Rollup.TxIngestionDBPort),
+		EnvVar: "TX_INGESTION_DB_PORT",
 	}
 	TxIngestionDBNameFlag = cli.StringFlag{
-		Name:  "txingestion.dbname",
-		Usage: "Database name to ingest transactions from",
-		Value: eth.DefaultConfig.Rollup.TxIngestionDBName,
+		Name:   "txingestion.dbname",
+		Usage:  "Database name to ingest transactions from",
+		Value:  eth.DefaultConfig.Rollup.TxIngestionDBName,
+		EnvVar: "TX_INGESTION_DB_NAME",
 	}
 	TxIngestionDBUserFlag = cli.StringFlag{
-		Name:  "txingestion.dbuser",
-		Usage: "Database username",
-		Value: eth.DefaultConfig.Rollup.TxIngestionDBUser,
+		Name:   "txingestion.dbuser",
+		Usage:  "Database username",
+		Value:  eth.DefaultConfig.Rollup.TxIngestionDBUser,
+		EnvVar: "TX_INGESTION_DB_USER",
 	}
 	TxIngestionDBPasswordFlag = cli.StringFlag{
-		Name:  "txingestion.dbpassword",
-		Usage: "Database password",
-		Value: eth.DefaultConfig.Rollup.TxIngestionDBPassword,
+		Name:   "txingestion.dbpassword",
+		Usage:  "Database password",
+		Value:  eth.DefaultConfig.Rollup.TxIngestionDBPassword,
+		EnvVar: "TX_INGESTION_DB_PASSWORD",
 	}
 	TxIngestionPollIntervalFlag = cli.DurationFlag{
-		Name:  "txingestion.pollinterval",
-		Usage: "Time between polls for tranaction ingestion",
-		Value: eth.DefaultConfig.Rollup.TxIngestionPollInterval,
+		Name:   "txingestion.pollinterval",
+		Usage:  "Time between polls for tranaction ingestion",
+		Value:  eth.DefaultConfig.Rollup.TxIngestionPollInterval,
+		EnvVar: "TX_INGESTION_POLL_INTERVAL",
 	}
 	TxIngestionSignerKeyHexFlag = cli.StringFlag{
 		Name:  "txingestion.signerkey",


### PR DESCRIPTION
## Description

Parse environment variables directly in geth. Move towards this for all configuration so that the docker entrypoint isn't necessary

## Questions
- Will upstream accept the changes?


## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.