### PR TITLE
Revert regression with zero address msg sender

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -17,7 +17,6 @@
 package core
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"math"
@@ -35,7 +34,6 @@ import (
 var (
 	errInsufficientBalanceForGas = errors.New("insufficient balance to pay for gas")
 	executionManagerAbi          abi.ABI
-	ZeroAddress                  = common.HexToAddress("0000000000000000000000000000000000000000")
 )
 
 func init() {
@@ -229,6 +227,11 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 		vmerr error
 	)
 
+	to := "<nil>"
+	if msg.To() != nil {
+		to = msg.To().Hex()
+	}
+
 	executionMgrTime := st.evm.Time
 	if executionMgrTime.Cmp(big.NewInt(0)) == 0 {
 		executionMgrTime = big.NewInt(1)
@@ -238,17 +241,11 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 	queueOrigin := big.NewInt(0)
 
 	l1MessageSender := msg.L1MessageSender()
-	if l1MessageSender == nil || bytes.Equal(l1MessageSender.Bytes(), ZeroAddress.Bytes()) {
-		addr := common.HexToAddress("0000000000000000000000000000000000000000")
+	if l1MessageSender == nil {
+		addr := common.HexToAddress("")
 		l1MessageSender = &addr
-	} else {
-		sender = vm.AccountRef(common.HexToAddress("0000000000000000000000000000000000000000"))
 	}
 
-	to := "<nil>"
-	if msg.To() != nil {
-		to = msg.To().Hex()
-	}
 	log.Debug("Applying transaction", "from", sender.Address().Hex(), "to", to, "nonce", msg.Nonce(), "l1MessageSender", l1MessageSender.Hex(), "data", hexutil.Encode(msg.Data()))
 
 	if contractCreation {


### PR DESCRIPTION
## Description
Fixes a bug where we weren't updating the nonce of real transaction `sender` causing infinite replay,


## Questions
None

## Metadata

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.