### PR TITLE
logs: compress pubkey in logs

### DIFF
--- a/rollup/transaction_ingestion.go
+++ b/rollup/transaction_ingestion.go
@@ -115,7 +115,7 @@ func (t *TxIngestion) loop() {
 		panic("Transaction ingestion requires a private key")
 	}
 
-	hex := hexutil.Encode(crypto.FromECDSAPub(&t.key.PublicKey))
+	hex := hexutil.Encode(crypto.CompressPubkey(&t.key.PublicKey))
 	address := crypto.PubkeyToAddress(t.key.PublicKey)
 	log.Info("Starting transaction ingestion", "key", hex, "address", address.Hex())
 


### PR DESCRIPTION
## Description

Logs the compressed public key instead of the uncompressed public key for the transaction ingestion signing key.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.