### PR TITLE
rollup: manage timestamps from L1 to L2 txs

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -206,7 +206,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		config.TxPool.Journal = ctx.ResolvePath(config.TxPool.Journal)
 	}
 	eth.txPool = core.NewTxPool(config.TxPool, chainConfig, eth.blockchain)
-	eth.txIngestion = rollup.NewTxIngestion(config.Rollup, chainConfig, eth.txPool)
+	eth.txIngestion = rollup.NewTxIngestion(config.Rollup, chainConfig, eth.txPool, eth.blockchain)
 
 	// Permit the downloader to use the trie cache allowance during fast sync
 	cacheLimit := cacheConfig.TrieCleanLimit + cacheConfig.TrieDirtyLimit

--- a/rollup/transaction_ingestion_test.go
+++ b/rollup/transaction_ingestion_test.go
@@ -35,7 +35,7 @@ func TestApplyTransaction(t *testing.T) {
 	chaincfg := params.ChainConfig{ChainID: chainId}
 
 	txPool := core.NewTxPool(core.TxPoolConfig{}, &chaincfg, chain)
-	txIngestion := NewTxIngestion(cfg, &chaincfg, txPool)
+	txIngestion := NewTxIngestion(cfg, &chaincfg, txPool, chain)
 
 	signer := types.NewOVMSigner(chainId)
 	tx, err := types.SignTx(types.NewTransaction(0, addr, new(big.Int), 21000, new(big.Int), []byte{}, &addr, nil, types.QueueOriginL1ToL2, types.SighashEIP155), signer, key)


### PR DESCRIPTION
## Description

This PR will update the blockchain time according the the timestamp on the block that includes the L1 to L2 transaction.

Closes https://github.com/ethereum-optimism/go-ethereum/issues/56


## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.