### PR TITLE
feature: state dump entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
 EXPOSE 8545 8546 8547 30303 30303/udp
 
 COPY docker/entrypoint.sh /bin
-RUN chmod +x /bin/entrypoint.sh
+COPY docker/state_dump_entrypoint.sh /bin
+RUN chmod +x /bin/entrypoint.sh \
+    && chmod +x /bin/state_dump_entrypoint.sh
 
 ENTRYPOINT ["sh", "/bin/entrypoint.sh"]

--- a/docker/dev_entrypoint.sh
+++ b/docker/dev_entrypoint.sh
@@ -3,9 +3,13 @@
 # Exits if any command fails
 set -e
 
-NETWORK_ID=${NETWORK_ID:-420}
+HOSTNAME=${HOSTNAME:-0.0.0.0}
 PORT=${PORT:-8545}
+NETWORK_ID=${NETWORK_ID:-420}
+VOLUME_PATH=${VOLUME_PATH:-/mnt/l2geth}
+
 TARGET_GAS_LIMIT=${TARGET_GAS_LIMIT:-8000000}
+
 TX_INGESTION=${TX_INGESTION:-false}
 TX_INGESTION_DB_HOST=${TX_INGESTION_DB_HOST:-localhost}
 TX_INGESTION_POLL_INTERVAL=${TX_INGESTION_POLL_INTERVAL:-3s}
@@ -24,6 +28,7 @@ else
       --rpcvhosts='*' \
       --rpccorsdomain='*' \
       --rpcport $PORT \
+      --ipcdisable \
       --networkid $NETWORK_ID \
       --rpcapi 'eth,net' \
       --gasprice '0' \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 ## Passed in from environment variables:
-# HOSTNAME=
-# PORT=8545
-# NETWORK_ID=420
-NETWORK_ID=${NETWORK_ID:-420}
+HOSTNAME=${HOSTNAME:-0.0.0.0}
 PORT=${PORT:-8545}
+NETWORK_ID=${NETWORK_ID:-420}
+VOLUME_PATH=${VOLUME_PATH:-/mnt/l2geth}
+
 CLEAR_DATA_FILE_PATH="${VOLUME_PATH}/.clear_data_key_${CLEAR_DATA_KEY}"
 TARGET_GAS_LIMIT=${TARGET_GAS_LIMIT:-8000000}
 TX_INGESTION=${TX_INGESTION:-false}
@@ -33,6 +33,7 @@ geth --dev \
   --rpccorsdomain='*' \
   --rpcport $PORT \
   --networkid $NETWORK_ID \
+  --ipcdisable \
   --rpcapi 'eth,net' \
   --gasprice '0' \
   --targetgaslimit $TARGET_GAS_LIMIT \

--- a/docker/state_dump_entrypoint.sh
+++ b/docker/state_dump_entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+HOSTNAME=${HOSTNAME:-0.0.0.0}
+PORT=${PORT:-8545}
+NETWORK_ID=${NETWORK_ID:-420}
+VOLUME_PATH=${VOLUME_PATH:-/mnt/l2geth}
+
+TARGET_GAS_LIMIT=${TARGET_GAS_LIMIT:-8000000}
+
+echo "Starting Geth in debug mode"
+## Command to kick off geth
+geth --dev \
+  --datadir $VOLUME_PATH \
+  --rpc \
+  --rpcaddr $HOSTNAME \
+  --rpcvhosts='*' \
+  --rpccorsdomain='*' \
+  --rpcport $PORT \
+  --networkid $NETWORK_ID \
+  --ipcdisable \
+  --rpcapi 'debug' \
+  --gasprice '0' \
+  --targetgaslimit $TARGET_GAS_LIMIT \
+  --nousb \
+  --gcmode=archive \
+  --verbosity "6" \
+  --txingestion.enable=false


### PR DESCRIPTION
## Description

Adds an additional script to the docker image so that it can be ran with an alternative entrypoint that starts geth with only the debug RPC. Transaction ingestion is turned off and the `eth` RPCs are turned off so that transactions cannot be added to the chain while in this mode.

Also turns off IPC

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.