### PR TITLE
Update flags.go

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -813,7 +813,7 @@ var (
 		Usage: "Deployment address of the L1 to L2 transaction queue",
 	}
 	Eth1SequencerDecompressionAddressFlag = cli.StringFlag{
-		Name:  "et1.sequencerdecompressionaddress",
+		Name:  "eth1.sequencerdecompressionaddress",
 		Usage: "Deployment address of the sequencer decompression contract",
 	}
 	Eth1ChainIdFlag = cli.Uint64Flag{


### PR DESCRIPTION
Fixes a typo in command line flags. Separately, where is the Sequencer Decompression contract? Can't seem to find it