### PR TITLE
rollup: mark txs are not executed in txcache

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -823,7 +823,7 @@ var (
 		Usage:  "HTTP endpoint of an eth 1 node",
 		EnvVar: "ETH1_HTTP",
 	}
-	Eth1ConfirmationDepth = cli.UintFlag{
+	Eth1ConfirmationDepth = cli.Uint64Flag{
 		Name:   "eth1.confirmationdepth",
 		Usage:  "Number of confirmations before ingesting L1 tx",
 		EnvVar: "ETH1_CONFIRMATION_DEPTH",

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -823,6 +823,11 @@ var (
 		Usage:  "HTTP endpoint of an eth 1 node",
 		EnvVar: "ETH1_HTTP",
 	}
+	Eth1ConfirmationDepth = cli.UintFlag{
+		Name:   "eth1.confirmationdepth",
+		Usage:  "Number of confirmations before ingesting L1 tx",
+		EnvVar: "ETH1_CONFIRMATION_DEPTH",
+	}
 	// Flag to enable verifier mode
 	RollupEnableVerifierFlag = cli.BoolFlag{
 		Name:   "rollup.verifier",
@@ -1078,6 +1083,9 @@ func setEth1(ctx *cli.Context, cfg *rollup.Config) {
 	}
 	if ctx.GlobalIsSet(Eth1HTTPFlag.Name) {
 		cfg.Eth1HTTPEndpoint = ctx.GlobalString(Eth1HTTPFlag.Name)
+	}
+	if ctx.GlobalIsSet(Eth1ConfirmationDepth.Name) {
+		cfg.Eth1ConfirmationDepth = ctx.GlobalUint64(Eth1ConfirmationDepth.Name)
 	}
 	if ctx.GlobalIsSet(Eth1SyncServiceEnable.Name) {
 		cfg.Eth1SyncServiceEnable = ctx.GlobalBool(Eth1SyncServiceEnable.Name)

--- a/rollup/config.go
+++ b/rollup/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	TxIngestionDBPassword   string
 	TxIngestionPollInterval time.Duration
 
+	// Number of confs before applying a L1 to L2 tx
+	Eth1ConfirmationDepth uint64
 	// Verifier mode
 	IsVerifier bool
 	// Enable the sync service

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -478,8 +478,10 @@ func (s *SyncService) sequencerIngestQueue() {
 				s.txCache.Range(func(index uint64, rtx *RollupTransaction) {
 					// The transaction has not been executed and is
 					// sufficiently old.
-					if !rtx.executed && tipHeight <= rtx.blockHeight+s.confirmationDepth {
+					if !rtx.executed && rtx.blockHeight+s.confirmationDepth >= tipHeight {
 						txs = append(txs, rtx)
+					} else if !rtx.executed {
+						log.Debug("Too early to execute tx", "enqueue-height", rtx.blockHeight, "tip-height", tipHeight, "queue-index", index)
 					}
 				})
 

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -478,7 +478,7 @@ func (s *SyncService) sequencerIngestQueue() {
 				s.txCache.Range(func(index uint64, rtx *RollupTransaction) {
 					// The transaction has not been executed
 					// TODO(mark): possibly add sufficiently old logic
-					if !rtx.executed && tipHeight < rtx.blockHeight+s.confirmationDepth {
+					if !rtx.executed && tipHeight <= rtx.blockHeight+s.confirmationDepth {
 						txs = append(txs, rtx)
 					}
 				})

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -476,8 +476,8 @@ func (s *SyncService) sequencerIngestQueue() {
 				// collect an array of pointers and then sort them by index.
 				txs := []*RollupTransaction{}
 				s.txCache.Range(func(index uint64, rtx *RollupTransaction) {
-					// The transaction has not been executed
-					// TODO(mark): possibly add sufficiently old logic
+					// The transaction has not been executed and is
+					// sufficiently old.
 					if !rtx.executed && tipHeight <= rtx.blockHeight+s.confirmationDepth {
 						txs = append(txs, rtx)
 					}

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -235,8 +235,8 @@ func (s *SyncService) Start() error {
 	if !s.enable {
 		return nil
 	}
-	log.Info("Initializing Sync Service", "endpoint", s.eth1HTTPEndpoint, "chainid", s.eth1ChainId, "networkid", s.eth1NetworkId, "address-resolver", s.AddressResolverAddress, "tx-ingestion-address", s.address)
-	log.Info("Watching topics", "transaction-enqueued", hexutil.Encode(transactionEnqueuedEventSignature), "queue-batch-appened", hexutil.Encode(queueBatchAppendedEventSignature), "sequencer-batch-appended", hexutil.Encode(sequencerBatchAppendedEventSignature), "confirmation-depth", s.confirmationDepth)
+	log.Info("Initializing Sync Service", "endpoint", s.eth1HTTPEndpoint, "chainid", s.eth1ChainId, "networkid", s.eth1NetworkId, "address-resolver", s.AddressResolverAddress, "tx-ingestion-address", s.address, "confirmation-depth", s.confirmationDepth)
+	log.Info("Watching topics", "transaction-enqueued", hexutil.Encode(transactionEnqueuedEventSignature), "queue-batch-appened", hexutil.Encode(queueBatchAppendedEventSignature), "sequencer-batch-appended", hexutil.Encode(sequencerBatchAppendedEventSignature))
 
 	// Always initialize syncing to true to start, the sequencer can toggle off
 	// syncing while the verifier is always syncing

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -478,7 +478,7 @@ func (s *SyncService) sequencerIngestQueue() {
 				s.txCache.Range(func(index uint64, rtx *RollupTransaction) {
 					// The transaction has not been executed and is
 					// sufficiently old.
-					if !rtx.executed && rtx.blockHeight+s.confirmationDepth >= tipHeight {
+					if !rtx.executed && rtx.blockHeight <= tipHeight {
 						txs = append(txs, rtx)
 					} else if !rtx.executed {
 						log.Debug("Too early to execute tx", "enqueue-height", rtx.blockHeight, "tip-height", tipHeight, "queue-index", index)


### PR DESCRIPTION
## Description

Make sure to set `executed=false` for txs that were reorg'd out in the txcache

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.