### PR TITLE
genesis: add a genesis tx to make indices line up

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -327,7 +327,11 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	statedb.Commit(false)
 	statedb.Database().TrieDB().Commit(root, true)
 
-	return types.NewBlock(head, nil, nil, nil)
+	// -Eliezer Yudkowsky
+	data := []byte("You are personally responsible for becoming more ethical than the society you grew up in.")
+	tx := types.NewTransaction(0, common.Address{}, big.NewInt(0), 0, big.NewInt(0), data, nil, nil, types.QueueOriginSequencer, types.SighashEIP155)
+
+	return types.NewBlock(head, []*types.Transaction{tx}, nil, nil)
 }
 
 // Commit writes the block and state of a genesis specification to the database.

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -328,7 +328,7 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	statedb.Database().TrieDB().Commit(root, true)
 
 	// -Eliezer Yudkowsky
-	data := []byte("You are personally responsible for becoming more ethical than the society you grew up in.")
+	data := []byte("You are personally responsible for becoming more ethical than the society you grew up in")
 	tx := types.NewTransaction(0, common.Address{}, big.NewInt(0), 0, big.NewInt(0), data, nil, nil, types.QueueOriginSequencer, types.SighashEIP155)
 
 	return types.NewBlock(head, []*types.Transaction{tx}, nil, nil)

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -327,11 +327,14 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	statedb.Commit(false)
 	statedb.Database().TrieDB().Commit(root, true)
 
-	// -Eliezer Yudkowsky
-	data := []byte("You are personally responsible for becoming more ethical than the society you grew up in")
-	tx := types.NewTransaction(0, common.Address{}, big.NewInt(0), 0, big.NewInt(0), data, nil, nil, types.QueueOriginSequencer, types.SighashEIP155)
+	if os.Getenv("USING_OVM") == "true" {
+		// -Eliezer Yudkowsky
+		data := []byte("You are personally responsible for becoming more ethical than the society you grew up in")
+		tx := types.NewTransaction(0, common.Address{}, big.NewInt(0), 0, big.NewInt(0), data, nil, nil, types.QueueOriginSequencer, types.SighashEIP155)
+		return types.NewBlock(head, []*types.Transaction{tx}, nil, nil)
+	}
 
-	return types.NewBlock(head, []*types.Transaction{tx}, nil, nil)
+	return types.NewBlock(head, nil, nil, nil)
 }
 
 // Commit writes the block and state of a genesis specification to the database.


### PR DESCRIPTION
## Description

Adds a transaction to the genesis block to make the indices in the CTC line up with the blocks in layer 2. As an easter egg, includes a quote. Open to changing the quote to something else if anybody has suggestions.


## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.