### PR TITLE
fix: env var parsing, api values

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -157,12 +157,14 @@ var (
 		utils.Eth1CanonicalTransactionChainDeployHeightFlag,
 		utils.Eth1CanonicalTransactionChainAddressFlag,
 		utils.Eth1SequencerDecompressionAddressFlag,
+		utils.Eth1L1CrossDomainMessengerAddressFlag,
 		utils.Eth1ChainIdFlag,
 		utils.Eth1NetworkIdFlag,
 		utils.Eth1HTTPFlag,
 		utils.Eth1ConfirmationDepth,
 		// Enable verifier mode
 		utils.RollupEnableVerifierFlag,
+		utils.RollupAddressManagerOwnerAddressFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1770,7 +1770,7 @@ type rollupAddresses struct {
 	CanonicalTransactionChain string `json:"canonicalTransactionChain"`
 	SequencerDecompression    string `json:"sequencerDecompression"`
 	StateCommitmentChain      string `json:"stateCommitmentChain"`
-	L1CrossDomainMessenger    string `json:"crossDomainMessenger"`
+	L1CrossDomainMessenger    string `json:"l1CrossDomainMessenger"`
 }
 
 type rollupInfo struct {
@@ -1810,7 +1810,7 @@ func (api *PublicRollupAPI) GetInfo(ctx context.Context) rollupInfo {
 	if scc != nil {
 		rollupAddrs.StateCommitmentChain = scc.Hex()
 	}
-	xdomain := addrs["l1CrossDomainMesenger"]
+	xdomain := addrs["l1CrossDomainMessengerAddress"]
 	if xdomain != nil {
 		rollupAddrs.L1CrossDomainMessenger = xdomain.Hex()
 	}


### PR DESCRIPTION
## Description

Fix the env var parsing, all new flags need to be added to the list in `cmd/geth/main.go` for them to actually be parsed. Also fix the API so that it returns the correct value.



## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.