### PR TITLE
ovm: set blocknumber correctly

### DIFF
--- a/core/state_transition_ovm.go
+++ b/core/state_transition_ovm.go
@@ -43,7 +43,7 @@ func init() {
 func toExecutionManagerRun(evm *vm.EVM, msg Message) (Message, error) {
 	tx := ovmTransaction{
 		evm.Context.Time,
-		evm.Context.BlockNumber, // TODO (what's the correct block number?)
+		msg.L1BlockNumber(),
 		uint8(msg.QueueOrigin().Uint64()),
 		*msg.L1MessageSender(),
 		*msg.To(),


### PR DESCRIPTION
## Description

Fixes the BlockNumber set in the execution context of the ExecutionManager
Depends on https://github.com/ethereum-optimism/go-ethereum/pull/114 for correctness

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.