### PR TITLE
StateDiff over Sqlite3

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -165,6 +165,7 @@ var (
 		// Enable verifier mode
 		utils.RollupEnableVerifierFlag,
 		utils.RollupAddressManagerOwnerAddressFlag,
+		utils.RollupDiffDbFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -78,6 +78,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.Eth1HTTPFlag,
 			utils.RollupAddressManagerOwnerAddressFlag,
 			utils.RollupEnableVerifierFlag,
+			utils.RollupDiffDbFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -849,6 +849,7 @@ var (
 	RollupDiffDbFlag = cli.Uint64Flag{
 		Name:   "rollup.diffdbcache",
 		Usage:  "Number of diffdb batch updates",
+		Value:  eth.DefaultConfig.DiffDbCache,
 		EnvVar: "ROLLUP_DIFFDB_CACHE",
 	}
 )

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -846,6 +846,11 @@ var (
 		Value:  "0x0000000000000000000000000000000000000000",
 		EnvVar: "ROLLUP_ADDRESS_MANAGER_OWNER_ADDRESS",
 	}
+	RollupDiffDbFlag = cli.Uint64Flag{
+		Name:   "rollup.diffdbcache",
+		Usage:  "Number of diffdb batch updates",
+		EnvVar: "ROLLUP_DIFFDB_CACHE",
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating
@@ -1603,6 +1608,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	setLes(ctx, cfg)
 	setEth1(ctx, &cfg.Rollup)
 
+	if ctx.GlobalIsSet(RollupDiffDbFlag.Name) {
+		cfg.DiffDbCache = ctx.GlobalUint64(RollupDiffDbFlag.Name)
+	}
 	if ctx.GlobalIsSet(SyncModeFlag.Name) {
 		cfg.SyncMode = *GlobalTextMarshaler(ctx, SyncModeFlag.Name).(*downloader.SyncMode)
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -904,6 +904,7 @@ func (bc *BlockChain) Stop() {
 			log.Error("Dangling trie nodes after full cleanup")
 		}
 	}
+	bc.diffdb.Close()
 	log.Info("Blockchain manager stopped")
 }
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -84,6 +84,7 @@ const (
 	maxTimeFutureBlocks = 30
 	badBlockLimit       = 10
 	TriesInMemory       = 128
+	diffDbCacheLimit    = 256
 
 	// BlockChainVersion ensures that an incompatible database forces a resync from scratch.
 	//
@@ -203,7 +204,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 	futureBlocks, _ := lru.New(maxFutureBlocks)
 	badBlocks, _ := lru.New(badBlockLimit)
 
-	diff, err := diffdb.NewDiffDb("eth/db/diffs")
+	diff, err := diffdb.NewDiffDb("diffs", diffDbCacheLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/core/dao_test.go
+++ b/core/dao_test.go
@@ -122,7 +122,6 @@ func TestDAOForkRangeExtradata(t *testing.T) {
 	gspec.MustCommit(db)
 	bc, _ := NewBlockChain(db, nil, &conConf, ethash.NewFaker(), vm.Config{}, nil)
 	defer bc.Stop()
-
 	blocks := conBc.GetBlocksFromHash(conBc.CurrentBlock().Hash(), int(conBc.CurrentBlock().NumberU64()))
 	for j := 0; j < len(blocks)/2; j++ {
 		blocks[j], blocks[len(blocks)-1-j] = blocks[len(blocks)-1-j], blocks[j]

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -60,7 +60,7 @@ func (n *proofList) Delete(key []byte) error {
 
 // DiffDb is a database for storing state diffs per block
 type DiffDB interface {
-	SetDiffKey(*big.Int, common.Address, common.Hash, bool)
+	SetDiffKey(*big.Int, common.Address, common.Hash, bool) error
 	GetDiff(*big.Int) (diffdb.Diff, error)
 }
 
@@ -150,8 +150,7 @@ func (s *StateDB) SetDiffKey(block *big.Int, address common.Address, key common.
 	if s.diffdb == nil {
 		return errors.New("DiffDB not set")
 	}
-	s.diffdb.SetDiffKey(block, address, key, mutated)
-	return nil
+	return s.diffdb.SetDiffKey(block, address, key, mutated)
 }
 
 func (s *StateDB) Error() error {

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -62,6 +62,7 @@ func (n *proofList) Delete(key []byte) error {
 type DiffDB interface {
 	SetDiffKey(*big.Int, common.Address, common.Hash, bool) error
 	GetDiff(*big.Int) (diffdb.Diff, error)
+	Close() error
 }
 
 // StateDBs within the ethereum protocol are used to store anything

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -63,6 +63,7 @@ type DiffDB interface {
 	SetDiffKey(*big.Int, common.Address, common.Hash, bool) error
 	GetDiff(*big.Int) (diffdb.Diff, error)
 	Close() error
+	ForceCommit() error
 }
 
 // StateDBs within the ethereum protocol are used to store anything

--- a/core/vm/ovm_state_manager_test.go
+++ b/core/vm/ovm_state_manager_test.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"crypto/rand"
 	"math/big"
+	"os"
 	"reflect"
 	"testing"
 
@@ -36,7 +37,8 @@ var (
 )
 
 func init() {
-	db, _ = diffdb.NewDiffDb("test")
+	os.Remove("test.db")
+	db, _ = diffdb.NewDiffDb("test.db", 1)
 	mock = &mockDb{db: *db}
 	env = NewEVM(Context{}, mock, params.TestChainConfig, Config{})
 	// re-use `dummyContractRef` from `logger_test.go`

--- a/diffdb/db.go
+++ b/diffdb/db.go
@@ -1,9 +1,10 @@
 package diffdb
 
 import (
-	"database/sql"
 	"github.com/ethereum/go-ethereum/common"
 	_ "github.com/mattn/go-sqlite3"
+
+	"database/sql"
 	"math/big"
 )
 

--- a/diffdb/db.go
+++ b/diffdb/db.go
@@ -125,6 +125,10 @@ func (diff *DiffDb) resetTx() error {
 	return nil
 }
 
+func (diff *DiffDb) Close() error {
+	return diff.db.Close()
+}
+
 /// Instantiates a new DiffDb using sqlite at `path`, with `cache` insertions
 /// done in a transaction before it gets committed to the database.
 func NewDiffDb(path string, cache uint64) (*DiffDb, error) {

--- a/diffdb/db_test.go
+++ b/diffdb/db_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestDiffDb(t *testing.T) {
 	os.Remove("./test_diff.db")
-	db, err := NewDiffDb("./test_diff.db")
+	db, err := NewDiffDb("./test_diff.db", 3)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/diffdb/db_test.go
+++ b/diffdb/db_test.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"os"
 )
 
-func TestInMemoryDb(t *testing.T) {
-	db, err := NewDiffDb("whatever")
+func TestDiffDb(t *testing.T) {
+	os.Remove("./test_diff.db")
+	db, err := NewDiffDb("./test_diff.db")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,7 +28,10 @@ func TestInMemoryDb(t *testing.T) {
 	db.SetDiffKey(big.NewInt(1), common.Address{0x2}, common.Hash{0x99}, false)
 	db.SetDiffKey(big.NewInt(2), common.Address{0x2}, common.Hash{0x98}, true)
 
-	diff, _ := db.GetDiff(big.NewInt(1))
+	diff, err := db.GetDiff(big.NewInt(1))
+	if err != nil {
+		t.Fatal("Did not expect error")
+	}
 	for i := range hashes {
 		if hashes[i] != diff[addr][i].Key {
 			t.Fatalf("Did not match")
@@ -37,4 +42,5 @@ func TestInMemoryDb(t *testing.T) {
 	if diff[common.Address{0x2}][0].Mutated != true {
 		t.Fatalf("Did not match mutated")
 	}
+	os.Remove("./test_diff.db")
 }

--- a/diffdb/db_test.go
+++ b/diffdb/db_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 func TestDiffDb(t *testing.T) {
-	os.Remove("./test_diff.db")
 	db, err := NewDiffDb("./test_diff.db", 3)
+	// cleanup (sqlite will create the file if it doesn't exist)
+	defer os.Remove("./test_diff.db")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,5 +43,4 @@ func TestDiffDb(t *testing.T) {
 	if diff[common.Address{0x2}][0].Mutated != true {
 		t.Fatalf("Did not match mutated")
 	}
-	os.Remove("./test_diff.db")
 }

--- a/diffdb/db_test.go
+++ b/diffdb/db_test.go
@@ -2,10 +2,10 @@ package diffdb
 
 import (
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"os"
 )
 
 func TestDiffDb(t *testing.T) {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"path/filepath"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -188,7 +189,10 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 			TrieTimeLimit:       config.TrieTimeout,
 		}
 	)
-	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, chainConfig, eth.engine, vmConfig, eth.shouldPreserve)
+
+	// Save the diffdb under chaindata/diffdb
+	diffdbPath := filepath.Join(ctx.ResolvePath("chaindata"), "diffdb")
+	eth.blockchain, err = core.NewBlockChainWithDiffDb(chainDb, cacheConfig, chainConfig, eth.engine, vmConfig, eth.shouldPreserve, diffdbPath, config.DiffDbCache)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/config.go
+++ b/eth/config.go
@@ -71,6 +71,7 @@ var DefaultConfig = Config{
 		TxIngestionDBUser:       "test",
 		TxIngestionDBPassword:   "test",
 	},
+	DiffDbCache: 256,
 }
 
 func init() {
@@ -127,6 +128,7 @@ type Config struct {
 	DatabaseHandles    int  `toml:"-"`
 	DatabaseCache      int
 	DatabaseFreezer    string
+	DiffDbCache        uint64
 
 	TrieCleanCache int
 	TrieDirtyCache int

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/lib/pq v1.0.0
 	github.com/mattn/go-colorable v0.1.0
 	github.com/mattn/go-isatty v0.0.5-0.20180830101745-3fb116b82035
+	github.com/mattn/go-sqlite3 v1.9.0
 	github.com/naoina/go-stringutil v0.1.0 // indirect
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
 	github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c


### PR DESCRIPTION
Replaces the in-memory map from #118 with Sqlite3. The db is stored under `chaindata/diffdb`. It stored data in memory and writes to the db / flushes memory every N calls, set by a CLI param which defaults to 256.