### PR TITLE
ovm: don't log error word

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -59,7 +59,7 @@ func run(evm *EVM, contract *Contract, input []byte, readOnly bool) ([]byte, err
 				abi := &(account.ABI)
 				method, err := abi.MethodById(input)
 				if err != nil {
-					log.Debug("Calling Known Contract", "Name", name, "ERROR", err)
+					log.Debug("Calling Known Contract", "Name", name, "Message", err)
 				} else {
 					log.Debug("Calling Known Contract", "Name", name, "Method", method.RawName)
 				}


### PR DESCRIPTION
## Description

This PR replaces the word `ERROR` in a logline with the word `Message` so that it will not trigger error alerting

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.