### PR TITLE
core: fix txs stuck in queue

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1225,7 +1225,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 
 		// Gather all executable transactions and promote them
 		nonce := pool.pendingNonces.get(addr)
-		readies := types.Transactions{}
+		var readies types.Transactions
 		// QueueOriginL1ToL2 transactions do not increment the nonce
 		// and the sender is the zero address, always promote them.
 		if os.Getenv("USING_OVM") == "true" {


### PR DESCRIPTION
## Description

Fix the non-determinism in the mempool by always promoting transactions from the zero address, this means they are queue origin L1 to L2. They will be sorted by the heap the miner uses 

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.