### PR TITLE
types: fix enums to match batch submitter

### DIFF
--- a/core/state_transition_ovm.go
+++ b/core/state_transition_ovm.go
@@ -98,7 +98,7 @@ func asOvmMessage(tx *types.Transaction, signer types.Signer, decompressor commo
 	// inserting into Geth so we can make transactions easily parseable. However, this means that
 	// we need to re-encode the transactions before executing them.
 	var data = new(bytes.Buffer)
-	data.WriteByte(getSignatureType(msg))                    // 1 byte: 00 == EIP 155, 02 == ETH Sign Message
+	data.WriteByte(uint8(msg.SignatureHashType()))           // 1 byte: 00 == EIP 155, 01 == ETH Sign Message
 	data.Write(fillBytes(r, 32))                             // 32 bytes: Signature `r` parameter
 	data.Write(fillBytes(s, 32))                             // 32 bytes: Signature `s` parameter
 	data.Write(fillBytes(v, 1))                              // 1 byte: Signature `v` parameter
@@ -178,18 +178,6 @@ func modMessage(
 	)
 
 	return outmsg, nil
-}
-
-func getSignatureType(
-	msg Message,
-) uint8 {
-	if msg.SignatureHashType() == 0 {
-		return 0
-	} else if msg.SignatureHashType() == 1 {
-		return 2
-	} else {
-		return 1
-	}
 }
 
 func getQueueOrigin(

--- a/rollup/types.go
+++ b/rollup/types.go
@@ -243,8 +243,8 @@ type CTCTransactionType uint8
 
 const (
 	CTCTransactionTypeEIP155  CTCTransactionType = 0
-	CTCTransactionTypeEOA     CTCTransactionType = 1
-	CTCTransactionTypeEthSign CTCTransactionType = 2
+	CTCTransactionTypeEthSign CTCTransactionType = 1
+	CTCTransactionTypeEOA     CTCTransactionType = 2
 )
 
 type CTCTransaction struct {


### PR DESCRIPTION
## Description

Fixes the enum for the Canonical Transaction Chain transactions so it matches what is in the batch submitter and in the contracts.

See:
https://github.com/ethereum-optimism/optimism-monorepo/blob/a37b46f6ffa9a7868d449c3bb4b067cd9bf64c29/packages/batch-submitter/src/coders/ecdsa-coder.ts#L17
https://github.com/ethereum-optimism/contracts-v2/blob/96baeba3feabdac09c9d9dd121c31bc2d2b63e7e/contracts/optimistic-ethereum/libraries/codec/Lib_OVMCodec.sol#L36

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.