### PR TITLE
L1Timestamp: set initial value correctly

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -521,6 +521,11 @@ func (bc *BlockChain) CurrentBlock() *types.Block {
 	return bc.currentBlock.Load().(*types.Block)
 }
 
+// SetCurrentBlock is used for testing
+func (bc *BlockChain) SetCurrentBlock(block *types.Block) {
+	bc.currentBlock.Store(block)
+}
+
 // CurrentFastBlock retrieves the current fast-sync head block of the canonical
 // chain. The block is retrieved from the blockchain's internal cache.
 func (bc *BlockChain) CurrentFastBlock() *types.Block {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -236,8 +236,6 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 	bc.currentBlock.Store(nilBlock)
 	bc.currentFastBlock.Store(nilBlock)
 
-	// TODO: Make default current timestamp configurable & make 0 if genesis else load from last block?
-
 	// Initialize the chain with ancient data if it isn't empty.
 	if bc.empty() {
 		rawdb.InitDatabaseFromFreezer(bc.db)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -885,7 +885,7 @@ func (w *worker) commitNewTx(tx *types.Transaction) error {
 		Number:     num.Add(num, common.Big1),
 		GasLimit:   core.CalcGasLimit(parent, w.config.GasFloor, w.config.GasCeil),
 		Extra:      w.extra,
-		Time:       uint64(timestamp),
+		Time:       timestamp,
 	}
 	if err := w.engine.Prepare(w.chain, header); err != nil {
 		return fmt.Errorf("Failed to prepare header for mining: %w", err)

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -360,7 +360,7 @@ func (s *SyncService) initializeLatestL1() error {
 		head := rawdb.ReadHeadBlockHash(s.db)
 		block := s.bc.GetBlockByHash(head)
 		txs := block.Transactions()
-		if len(txs) == 0 {
+		if len(txs) != 1 {
 			log.Error("Unexpected number of transactions in block: %d", len(txs))
 		}
 		if len(txs) > 0 {

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -360,12 +360,14 @@ func (s *SyncService) initializeLatestL1() error {
 		head := rawdb.ReadHeadBlockHash(s.db)
 		block := s.bc.GetBlockByHash(head)
 		txs := block.Transactions()
-		if len(txs) > 0 {
-			return fmt.Errorf("")
+		if len(txs) == 0 {
+			log.Error("Unexpected number of transactions in block: %d", len(txs))
 		}
-		tx := txs[0]
-		s.SetLatestL1Timestamp(tx.L1Timestamp())
-		s.SetLatestL1BlockNumber(tx.L1BlockNumber().Uint64())
+		if len(txs) > 0 {
+			tx := txs[0]
+			s.SetLatestL1Timestamp(tx.L1Timestamp())
+			s.SetLatestL1BlockNumber(tx.L1BlockNumber().Uint64())
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Description

Sets the initial `L1Timestamp` and `L1BlockNumber` correctly on startup, includes tests coverage

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.