### PR TITLE
sync-fix: process historical logs determinism

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -454,6 +454,11 @@ func startNode(ctx *cli.Context, stack *node.Node) {
 		if err := ethereum.StartMining(threads); err != nil {
 			utils.Fatalf("Failed to start mining: %v", err)
 		}
+		if ctx.GlobalBool(utils.Eth1SyncServiceEnable.Name) {
+			if err := ethereum.SyncService().Start(); err != nil {
+				utils.Fatalf("Failed to start syncservice: %v", err)
+			}
+		}
 	}
 }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -540,13 +540,6 @@ func (s *Ethereum) Start(srvr *p2p.Server) error {
 
 	// Start the RPC service
 	s.netRPCService = ethapi.NewPublicNetAPI(srvr, s.NetVersion())
-
-	// Start the sync service
-	err := s.syncService.Start()
-	if err != nil {
-		return fmt.Errorf("unable to start syncservice: %w", err)
-	}
-
 	return nil
 }
 

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -769,7 +769,7 @@ func (s *SyncService) processHistoricalLogs() error {
 				Addresses: []common.Address{
 					s.CanonicalTransactionChainAddress,
 				},
-				FromBlock: new(big.Int).SetUint64(s.Eth1Data.BlockHeight),
+				FromBlock: new(big.Int).SetUint64(s.Eth1Data.BlockHeight + 1),
 				ToBlock:   new(big.Int).SetUint64(s.Eth1Data.BlockHeight + 1000),
 				Topics:    [][]common.Hash{},
 			}


### PR DESCRIPTION
## Description

Adds processing of historical logs over ranges of logs so that a verifier can sync in a reasonable amount of time. The initial implementation included an off by one error in the fetching of the logs. This PR also starts the RPC server before historical log processing starts.

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.