### PR TITLE
Fix the block that we get state diffs for

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -573,7 +573,7 @@ func (s *PublicBlockChainAPI) GetStateDiff(ctx context.Context, blockNrOrHash rp
 	if err != nil {
 		return nil, err
 	}
-	return s.b.GetDiff(header.Number)
+	return s.b.GetDiff(new(big.Int).Add(header.Number, big.NewInt(1)))
 }
 
 // GetStateDiffProof returns the Merkle-proofs corresponding to all the accounts and


### PR DESCRIPTION
## Description
We need to get diff for `n+1`, not `n`.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.