### PR TITLE
minnet: disable erc20 transfers

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -168,6 +168,7 @@ var (
 		utils.RollupAddressManagerOwnerAddressFlag,
 		utils.RollupStateDumpPathFlag,
 		utils.RollupDiffDbFlag,
+		utils.RollupDisableTransfersFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -80,6 +80,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.RollupEnableVerifierFlag,
 			utils.RollupStateDumpPathFlag,
 			utils.RollupDiffDbFlag,
+			utils.RollupDisableTransfersFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -864,6 +864,11 @@ var (
 		Value:  eth.DefaultConfig.DiffDbCache,
 		EnvVar: "ROLLUP_DIFFDB_CACHE",
 	}
+	RollupDisableTransfersFlag = cli.BoolFlag{
+		Name:   "rollup.disabletransfers",
+		Usage:  "Disable Transfers",
+		EnvVar: "ROLLUP_DISABLE_TRANSFERS",
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating
@@ -1161,6 +1166,9 @@ func setRollup(ctx *cli.Context, cfg *rollup.Config) {
 		cfg.StateDumpPath = ctx.GlobalString(RollupStateDumpPathFlag.Name)
 	} else {
 		cfg.StateDumpPath = eth.DefaultConfig.Rollup.StateDumpPath
+	}
+	if ctx.GlobalIsSet(RollupDisableTransfersFlag.Name) {
+		cfg.DisableTransfers = true
 	}
 }
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -283,10 +283,14 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 				data := signedTx.Data()
 				if len(data) >= 4 {
 					selector := data[:4]
-					// 0xa9059cbb is the selector for `transfer(address,uint256)`
-					// Do not allow transfers at first
+					// Initially prevent transfers
+					// `transfer(address,uint256)`
 					if bytes.Equal(selector, []byte{0xa9, 0x05, 0x9c, 0xbb}) {
-						return errors.New("Transfers are disabled for minnet")
+						return errors.New("transfer(address,uint256) is disabled for now")
+					}
+					// `transferFrom(address,address,uint256)`
+					if bytes.Equal(selector, []byte{0x23, 0xb8, 0x72, 0xdd}) {
+						return errors.New("transferFrom(address,address,uint256) is disabled for now")
 					}
 				}
 			}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -283,8 +283,8 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 				data := signedTx.Data()
 				if len(data) >= 4 {
 					selector := data[:4]
-					// 0xa9059cbb is the selector for `Transfer(address,uint256)`
-					// Do not allow transfers on mainnet
+					// 0xa9059cbb is the selector for `transfer(address,uint256)`
+					// Do not allow transfers at first
 					if bytes.Equal(selector, []byte{0xa9, 0x05, 0x9c, 0xbb}) {
 						return errors.New("Transfers are disabled for minnet")
 					}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -226,7 +226,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
-	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth, nil, config.Rollup.IsVerifier}
+	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth, nil, config.Rollup.IsVerifier, config.Rollup.DisableTransfers}
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {
 		gpoParams.Default = config.Miner.GasPrice

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -84,7 +84,6 @@ type Backend interface {
 	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription
 
 	// Optimism-specific API
-	SendTxs(ctx context.Context, signedTxs []*types.Transaction) []error
 	SetTimestamp(timestamp int64)
 	IsVerifier() bool
 	RollupTransactionSender() *common.Address

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -210,10 +210,6 @@ func (b *LesApiBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 	return b.eth.txPool.Add(ctx, signedTx)
 }
 
-func (b *LesApiBackend) SendTxs(ctx context.Context, signedTxs []*types.Transaction) []error {
-	return b.eth.txPool.AddBatch(ctx, signedTxs)
-}
-
 func (b *LesApiBackend) SetTimestamp(timestamp int64) {
 	// Intentionally empty because this is not needed for LightChain
 }

--- a/rollup/config.go
+++ b/rollup/config.go
@@ -36,6 +36,8 @@ type Config struct {
 	CanonicalTransactionChainDeployHeight *big.Int
 	// Path to the state dump
 	StateDumpPath string
+	// Temporary setting to disable transfers
+	DisableTransfers bool
 }
 
 func (c *Config) IsTxIngestionEnabled() bool {


### PR DESCRIPTION
## Description
Disable transfers based on the selector using a config option
A flag `rollup.disabletransfers` or env var `ROLLUP_DISABLE_TRANSFERS` can be used. It is off by default.

Both `transfer(address,uint256)` and `transferFrom(address,address,uint256)` are disabled, based on https://github.com/Synthetixio/synthetix/blob/424bb619c3685128da244d14f3cd91bba37770e4/contracts/ProxyERC20.sol

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.