### PR TITLE
diffdb: use >=

### DIFF
--- a/diffdb/db.go
+++ b/diffdb/db.go
@@ -65,7 +65,7 @@ func (diff *DiffDb) SetDiffKey(block *big.Int, address common.Address, key commo
 	diff.numCalls += 1
 
 	// if we had enough calls, commit it
-	if diff.numCalls == diff.cache {
+	if diff.numCalls >= diff.cache {
 		if err := diff.ForceCommit(); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

Update the commit check in the diffdb to use `>=` instead of `==` to prevent a possible bug where the `numCalls` ends up becoming too large

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.