### PR TITLE
rollup: to block max value to prevent tx replay

### DIFF
--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -738,6 +738,11 @@ func (s *SyncService) processHistoricalLogs() error {
 				errCh <- fmt.Errorf("Eth1 chain not synced: height %d", tipHeight)
 			}
 
+			fromBlock := s.Eth1Data.BlockHeight + 1
+			if tipHeight < fromBlock {
+				fromBlock = tipHeight
+			}
+
 			// Use the tip height as the max value
 			toBlock := s.Eth1Data.BlockHeight + 1000
 			if tipHeight < toBlock {
@@ -748,7 +753,7 @@ func (s *SyncService) processHistoricalLogs() error {
 				Addresses: []common.Address{
 					s.CanonicalTransactionChainAddress,
 				},
-				FromBlock: new(big.Int).SetUint64(s.Eth1Data.BlockHeight + 1),
+				FromBlock: new(big.Int).SetUint64(fromBlock),
 				ToBlock:   new(big.Int).SetUint64(toBlock),
 				Topics:    [][]common.Hash{},
 			}

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -738,12 +738,18 @@ func (s *SyncService) processHistoricalLogs() error {
 				errCh <- fmt.Errorf("Eth1 chain not synced: height %d", tipHeight)
 			}
 
+			// Use the tip height as the max value
+			toBlock := s.Eth1Data.BlockHeight + 1000
+			if tipHeight < toBlock {
+				toBlock = tipHeight
+			}
+
 			query := ethereum.FilterQuery{
 				Addresses: []common.Address{
 					s.CanonicalTransactionChainAddress,
 				},
 				FromBlock: new(big.Int).SetUint64(s.Eth1Data.BlockHeight + 1),
-				ToBlock:   new(big.Int).SetUint64(s.Eth1Data.BlockHeight + 1000),
+				ToBlock:   new(big.Int).SetUint64(toBlock),
 				Topics:    [][]common.Hash{},
 			}
 


### PR DESCRIPTION
## Description

An error is returned when a filter query is sent where the `fromBlock` is larger than the tip height. This PR adds a check so that the `fromBlock` will at most be the tip height.

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [ ] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.