### PR TITLE
rollup: safer historical log syncing

### DIFF
--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -772,6 +772,7 @@ func (s *SyncService) processHistoricalLogs() error {
 					continue
 				}
 				s.Eth1Data = eth1data
+
 				log.Info("Processed historical block", "height", headerHeight, "hash", headerHash.Hex())
 				s.doneProcessing <- headerHeight
 			} else {
@@ -786,11 +787,13 @@ func (s *SyncService) processHistoricalLogs() error {
 						continue
 					}
 
+					rawdb.WriteHeadEth1HeaderHash(s.db, ethlog.BlockHash)
+					rawdb.WriteHeadEth1HeaderHeight(s.db, ethlog.BlockNumber)
+
 					s.Eth1Data = Eth1Data{
 						BlockHash:   ethlog.BlockHash,
 						BlockHeight: ethlog.BlockNumber,
 					}
-
 					log.Info("Processed historical block", "height", ethlog.BlockNumber, "hash", ethlog.BlockHash.Hex())
 					s.doneProcessing <- ethlog.BlockNumber
 				}


### PR DESCRIPTION
## Description

Makes the historical log syncing more safe by indexing the latest processed block height so that a restart during historical syncing will not result in an inconsistent state.

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.