### PR TITLE
rollup: better log message + reorg on failure

### DIFF
--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -742,8 +742,11 @@ func (s *SyncService) processHistoricalLogs() error {
 			}
 
 			if tipHeight < s.Eth1Data.BlockHeight {
-				log.Error("Historical block processing tip is earlier than last processed block height")
-				errCh <- fmt.Errorf("Eth1 chain not synced: height %d", tipHeight)
+				if err := s.bc.SetHead(1); err != nil {
+					log.Error("Problem syncing", "message", err)
+				}
+				s.Eth1Data = Eth1Data{BlockHeight: 1}
+				continue
 			}
 
 			// The above checks prevent `fromBlock` from being

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -766,7 +766,7 @@ func (s *SyncService) processHistoricalLogs() error {
 
 			logs, err := s.logClient.FilterLogs(s.ctx, query)
 			if err != nil {
-				log.Error("Cannot query logs", "message", err)
+				log.Error("Cannot query logs", "from", fromBlock, "to", toBlock, "message", err)
 				continue
 			}
 			if len(logs) == 0 {


### PR DESCRIPTION
## Description

Adds a better log message for the getLogs call in historical syncing

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [ ] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.