### PR TITLE
gasLimit: error on gas limit too high for queue origin sequencer txs

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -282,7 +282,7 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 			}
 
 			// Prevent transactions from being submitted if the gas limit too high
-			if signedTx.Gas() > b.GasLimit {
+			if signedTx.Gas() >= b.GasLimit {
 				return fmt.Errorf("Transaction gasLimit (%d) is greater than max gasLimit (%d)", signedTx.Gas(), b.GasLimit)
 			}
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -50,6 +50,7 @@ type EthAPIBackend struct {
 	verifier         bool
 	DisableTransfers bool
 	GasLimit         uint64
+	UsingOVM         bool
 }
 
 func (b *EthAPIBackend) RollupTransactionSender() *common.Address {
@@ -273,7 +274,7 @@ func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 // Transactions originating from the RPC endpoints are added to remotes so that
 // a lock can be used around the remotes for when the sequencer is reorganizing.
 func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
-	if vm.UsingOVM {
+	if b.UsingOVM {
 		to := signedTx.To()
 		if to != nil {
 			if *to == (common.Address{}) {
@@ -301,9 +302,10 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 				}
 			}
 		}
-
+		return b.eth.syncService.ApplyTransaction(signedTx)
 	}
-	return b.eth.syncService.ApplyTransaction(signedTx)
+	// OVM Disabled
+	return b.eth.txPool.AddLocal(signedTx)
 }
 
 func (b *EthAPIBackend) SetTimestamp(timestamp int64) {

--- a/eth/api_backend_test.go
+++ b/eth/api_backend_test.go
@@ -41,12 +41,4 @@ func TestGasLimit(t *testing.T) {
 	if err.Error() != fmt.Sprintf("Transaction gasLimit (%d) is greater than max gasLimit (%d)", gasLimit, backend.GasLimit) {
 		t.Fatalf("Unexpected error type: %s", err)
 	}
-
-	// Create a new tx with a gas limit of 0
-	gasLimit = uint64(0)
-	tx = types.NewTransaction(nonce, to, value, gasLimit, gasPrice, data, nil, nil, qo, sighash)
-	err = backend.SendTx(context.Background(), tx)
-	if err != nil {
-		t.Fatal("Transaction with too large of gas limit accepted")
-	}
 }

--- a/eth/api_backend_test.go
+++ b/eth/api_backend_test.go
@@ -1,0 +1,52 @@
+package eth
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+func TestGasLimit(t *testing.T) {
+	backend := &EthAPIBackend{
+		extRPCEnabled:    false,
+		eth:              nil,
+		gpo:              nil,
+		verifier:         false,
+		DisableTransfers: false,
+		GasLimit:         0,
+		UsingOVM:         true,
+	}
+
+	nonce := uint64(0)
+	to := common.HexToAddress("0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c")
+	value := big.NewInt(0)
+	gasPrice := big.NewInt(0)
+	data := []byte{}
+	qo := types.QueueOriginSequencer
+	sighash := types.SighashEIP155
+
+	// Set the gas limit to 1 so that the transaction will not be
+	// able to be added.
+	gasLimit := uint64(1)
+	tx := types.NewTransaction(nonce, to, value, gasLimit, gasPrice, data, nil, nil, qo, sighash)
+
+	err := backend.SendTx(context.Background(), tx)
+	if err == nil {
+		t.Fatal("Transaction with too large of gas limit accepted")
+	}
+	if err.Error() != fmt.Sprintf("Transaction gasLimit (%d) is greater than max gasLimit (%d)", gasLimit, backend.GasLimit) {
+		t.Fatalf("Unexpected error type: %s", err)
+	}
+
+	// Create a new tx with a gas limit of 0
+	gasLimit = uint64(0)
+	tx = types.NewTransaction(nonce, to, value, gasLimit, gasPrice, data, nil, nil, qo, sighash)
+	err = backend.SendTx(context.Background(), tx)
+	if err != nil {
+		t.Fatal("Transaction with too large of gas limit accepted")
+	}
+}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -226,7 +226,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
-	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth, nil, config.Rollup.IsVerifier, config.Rollup.DisableTransfers, config.Rollup.GasLimit}
+	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth, nil, config.Rollup.IsVerifier, config.Rollup.DisableTransfers, config.Rollup.GasLimit, vm.UsingOVM}
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {
 		gpoParams.Default = config.Miner.GasPrice

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -226,7 +226,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
-	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth, nil, config.Rollup.IsVerifier, config.Rollup.DisableTransfers}
+	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth, nil, config.Rollup.IsVerifier, config.Rollup.DisableTransfers, config.Rollup.GasLimit}
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {
 		gpoParams.Default = config.Miner.GasPrice


### PR DESCRIPTION
## Description

Adds a fix for queue origin sequencer transactions for when the gas limit is too high. Prevents the transactions from being passed through because they are unable to be included in the chain and returns an error message.

The parsed configuration for gas limit is passed through to the `Backend` which is the closest common point for any tx coming in via RPC to the tx execution.

Adds a simple test that the check works as expected.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.