### PR TITLE
config: flag for max acceptable calldata size

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -150,9 +150,6 @@ var (
 	}
 
 	optimismFlags = []cli.Flag{
-		// Flags for the SyncService
-		utils.TxIngestionSignerKeyHexFlag,
-		utils.TxIngestionSignerKeyFileFlag,
 		utils.Eth1SyncServiceEnable,
 		utils.Eth1AddressResolverAddressFlag,
 		utils.Eth1CanonicalTransactionChainDeployHeightFlag,
@@ -169,6 +166,7 @@ var (
 		utils.RollupStateDumpPathFlag,
 		utils.RollupDiffDbFlag,
 		utils.RollupDisableTransfersFlag,
+		utils.RollupMaxCalldataSizeFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -65,8 +65,6 @@ var AppHelpFlagGroups = []flagGroup{
 	{
 		Name: "OPTIMISM",
 		Flags: []cli.Flag{
-			utils.TxIngestionSignerKeyHexFlag,
-			utils.TxIngestionSignerKeyFileFlag,
 			utils.Eth1SyncServiceEnable,
 			utils.Eth1AddressResolverAddressFlag,
 			utils.Eth1CanonicalTransactionChainDeployHeightFlag,
@@ -81,6 +79,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.RollupStateDumpPathFlag,
 			utils.RollupDiffDbFlag,
 			utils.RollupDisableTransfersFlag,
+			utils.RollupMaxCalldataSizeFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -870,6 +870,12 @@ var (
 		Usage:  "Disable Transfers",
 		EnvVar: "ROLLUP_DISABLE_TRANSFERS",
 	}
+	RollupMaxCalldataSizeFlag = cli.IntFlag{
+		Name:   "rollup.maxcalldatasize",
+		Usage:  "Maximum allowed calldata size for Queue Origin Sequencer Txs",
+		Value:  eth.DefaultConfig.Rollup.MaxCallDataSize,
+		EnvVar: "ROLLUP_MAX_CALLDATA_SIZE",
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating
@@ -1170,6 +1176,9 @@ func setRollup(ctx *cli.Context, cfg *rollup.Config) {
 	}
 	if ctx.GlobalIsSet(RollupDisableTransfersFlag.Name) {
 		cfg.DisableTransfers = true
+	}
+	if ctx.GlobalIsSet(RollupMaxCalldataSizeFlag.Name) {
+		cfg.MaxCallDataSize = ctx.GlobalInt(RollupMaxCalldataSizeFlag.Name)
 	}
 }
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -287,10 +287,6 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 				return fmt.Errorf("Transaction gasLimit (%d) is greater than max gasLimit (%d)", signedTx.Gas(), b.GasLimit)
 			}
 
-			if len(signedTx.Data()) > b.MaxCallDataSize {
-				return fmt.Errorf("Calldata too large")
-			}
-
 			if b.DisableTransfers {
 				data := signedTx.Data()
 				if len(data) >= 4 {
@@ -304,6 +300,10 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 					if bytes.Equal(selector, []byte{0x23, 0xb8, 0x72, 0xdd}) {
 						return errors.New("transferFrom(address,address,uint256) is disabled for now")
 					}
+				}
+
+				if len(signedTx.Data()) > b.MaxCallDataSize {
+					return fmt.Errorf("Calldata cannot be larger than %d, sent %d", b.MaxCallDataSize, len(signedTx.Data()))
 				}
 			}
 		}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -51,6 +51,7 @@ type EthAPIBackend struct {
 	DisableTransfers bool
 	GasLimit         uint64
 	UsingOVM         bool
+	MaxCallDataSize  int
 }
 
 func (b *EthAPIBackend) RollupTransactionSender() *common.Address {
@@ -284,6 +285,10 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 			// Prevent transactions from being submitted if the gas limit too high
 			if signedTx.Gas() >= b.GasLimit {
 				return fmt.Errorf("Transaction gasLimit (%d) is greater than max gasLimit (%d)", signedTx.Gas(), b.GasLimit)
+			}
+
+			if len(signedTx.Data()) > b.MaxCallDataSize {
+				return fmt.Errorf("Calldata too large")
 			}
 
 			if b.DisableTransfers {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -226,7 +226,10 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
-	log.Info("Backend Config", "max-calldata-size", config.Rollup.MaxCallDataSize, "disable-transfers", config.Rollup.DisableTransfers, "gas-limit", config.Rollup.GasLimit, "is-verifier", config.Rollup.IsVerifier, "using-ovm", vm.UsingOVM)
+	log.Info("Backend Config", "disable-transfers", config.Rollup.DisableTransfers, "gas-limit", config.Rollup.GasLimit, "is-verifier", config.Rollup.IsVerifier, "using-ovm", vm.UsingOVM)
+	if config.Rollup.DisableTransfers {
+		log.Info("Transaction size restrictions", "max-calldata", config.Rollup.MaxCallDataSize)
+	}
 	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth, nil, config.Rollup.IsVerifier, config.Rollup.DisableTransfers, config.Rollup.GasLimit, vm.UsingOVM, config.Rollup.MaxCallDataSize}
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -226,6 +226,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
+	log.Info("Backend Config", "max-calldata-size", config.Rollup.MaxCallDataSize, "disable-transfers", config.Rollup.DisableTransfers, "gas-limit", config.Rollup.GasLimit, "is-verifier", config.Rollup.IsVerifier, "using-ovm", vm.UsingOVM)
 	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth, nil, config.Rollup.IsVerifier, config.Rollup.DisableTransfers, config.Rollup.GasLimit, vm.UsingOVM, config.Rollup.MaxCallDataSize}
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -226,7 +226,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	eth.miner = miner.New(eth, &config.Miner, chainConfig, eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
-	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth, nil, config.Rollup.IsVerifier, config.Rollup.DisableTransfers, config.Rollup.GasLimit, vm.UsingOVM}
+	eth.APIBackend = &EthAPIBackend{ctx.ExtRPCEnabled(), eth, nil, config.Rollup.IsVerifier, config.Rollup.DisableTransfers, config.Rollup.GasLimit, vm.UsingOVM, config.Rollup.MaxCallDataSize}
 	gpoParams := config.GPO
 	if gpoParams.Default == nil {
 		gpoParams.Default = config.Miner.GasPrice

--- a/eth/config.go
+++ b/eth/config.go
@@ -65,6 +65,7 @@ var DefaultConfig = Config{
 	Rollup: rollup.Config{
 		TxIngestionEnable: false,
 		StateDumpPath:     "https://raw.githubusercontent.com/ethereum-optimism/regenesis/master/master.json",
+		MaxCallDataSize:   512,
 	},
 	DiffDbCache: 256,
 }

--- a/rollup/config.go
+++ b/rollup/config.go
@@ -10,6 +10,8 @@ import (
 type Config struct {
 	// TODO(mark): deprecate these config options
 	TxIngestionEnable bool
+	// Maximum calldata size for a Queue Origin Sequencer Tx
+	MaxCallDataSize int
 	// Number of confs before applying a L1 to L2 tx
 	Eth1ConfirmationDepth uint64
 	// Verifier mode


### PR DESCRIPTION
## Description

Adds a configurable maximum calldata size for queue origin sequencer transactions. This PR depends on https://github.com/ethereum-optimism/go-ethereum/pull/180 being merged first so that it can be rebased on top

## Metadata
### Fixes
- https://github.com/ethereum-optimism/roadmap/issues/403

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.