### PR TITLE
Fixes issue with broken gas limit

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -438,9 +438,10 @@ var (
 		EnvVar: "TARGET_GAS_LIMIT",
 	}
 	MinerGasLimitFlag = cli.Uint64Flag{
-		Name:  "miner.gaslimit",
-		Usage: "Target gas ceiling for mined blocks",
-		Value: eth.DefaultConfig.Miner.GasCeil,
+		Name:   "miner.gaslimit",
+		Usage:  "Target gas ceiling for mined blocks",
+		Value:  eth.DefaultConfig.Miner.GasCeil,
+		EnvVar: "TARGET_GAS_LIMIT",
 	}
 	MinerGasPriceFlag = BigFlag{
 		Name:   "miner.gasprice",

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -883,7 +883,7 @@ func (w *worker) commitNewTx(tx *types.Transaction) error {
 	header := &types.Header{
 		ParentHash: parent.Hash(),
 		Number:     num.Add(num, common.Big1),
-		GasLimit:   core.CalcGasLimit(parent, w.config.GasFloor, w.config.GasCeil),
+		GasLimit:   w.config.GasFloor,
 		Extra:      w.extra,
 		Time:       timestamp,
 	}
@@ -917,7 +917,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 	header := &types.Header{
 		ParentHash: parent.Hash(),
 		Number:     num.Add(num, common.Big1),
-		GasLimit:   core.CalcGasLimit(parent, w.config.GasFloor, w.config.GasCeil),
+		GasLimit:   w.config.GasFloor,
 		Extra:      w.extra,
 		Time:       uint64(timestamp),
 	}


### PR DESCRIPTION
## Description
`w.config.GasCeil` was not correctly being initialized, meaning `CalcGasLimit` would start slowly reducing the gas limit. This clashed with a hack that we use to manually change the message gas limit later on, meaning the worker would try to apply the transaction and fail.

PR adds two lines of defense against this bug, first remove the `CalcGasLimit` logic from our worker since we don't actually need dynamic gas limits right now, and second make sure `w.config.GasCeil` is set via the single gas limit environment variable.

## Metadata
### Fixes
- Fixes https://github.com/ethereum-optimism/roadmap/issues/404

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.