### PR TITLE
debug rpc: debug_setL1Head and better l1 timestamp management

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -133,8 +133,8 @@ func (b *EthAPIBackend) SetHead(number uint64) {
 	b.eth.syncService.SetLatestL1BlockNumber(blockNumber.Uint64())
 }
 
-func (b *EthAPIBackend) SetL1Head(number uint64) {
-	b.eth.syncService.SetL1Head(number)
+func (b *EthAPIBackend) SetL1Head(number uint64) error {
+	return b.eth.syncService.SetL1Head(number)
 }
 
 func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -105,7 +105,13 @@ func (b *EthAPIBackend) GetDiff(block *big.Int) (diffdb.Diff, error) {
 }
 
 func (b *EthAPIBackend) SetHead(number uint64) {
-	b.eth.protocolManager.downloader.Cancel()
+	if number == 0 {
+		log.Info("Cannot reset to genesis")
+		return
+	}
+	if !b.UsingOVM {
+		b.eth.protocolManager.downloader.Cancel()
+	}
 	b.eth.blockchain.SetHead(number)
 
 	// Make sure to reset the LatestL1{Timestamp,BlockNumber}

--- a/eth/api_backend_test.go
+++ b/eth/api_backend_test.go
@@ -7,7 +7,15 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rollup"
 )
 
 func TestGasLimit(t *testing.T) {
@@ -41,4 +49,74 @@ func TestGasLimit(t *testing.T) {
 	if err.Error() != fmt.Sprintf("Transaction gasLimit (%d) is greater than max gasLimit (%d)", gasLimit, backend.GasLimit) {
 		t.Fatalf("Unexpected error type: %s", err)
 	}
+}
+
+func TestSetHead(t *testing.T) {
+	s, bc, db, err := newTestSyncService()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	backend := &EthAPIBackend{
+		eth: &Ethereum{
+			syncService: s,
+			blockchain:  bc,
+		},
+		UsingOVM: true,
+	}
+
+	// Insert a chain of 3
+	blocks := makeBlockChain(bc.CurrentBlock(), 3, ethash.NewFaker(), *db, 10)
+	_, err = bc.InsertChain(blocks)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert that the current block is height 3
+	current := backend.CurrentBlock()
+	if current.NumberU64() != 3 {
+		t.Fatal("Current doesn't match")
+	}
+
+	// Set the head to 1 and then make sure the tip is on 1
+	backend.SetHead(1)
+	current = backend.CurrentBlock()
+	if current.NumberU64() != 1 {
+		t.Fatal("Current doesn't match")
+	}
+}
+
+func newTestSyncService() (*rollup.SyncService, *core.BlockChain, *ethdb.Database, error) {
+	chainCfg := params.AllEthashProtocolChanges
+	chainID := big.NewInt(420)
+	chainCfg.ChainID = chainID
+
+	engine := ethash.NewFaker()
+	db := rawdb.NewMemoryDatabase()
+	_ = new(core.Genesis).MustCommit(db)
+	chain, err := core.NewBlockChain(db, nil, chainCfg, engine, vm.Config{}, nil)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Cannot initialize blockchain: %w", err)
+	}
+	chaincfg := params.ChainConfig{ChainID: chainID}
+
+	txPool := core.NewTxPool(core.TxPoolConfig{PriceLimit: 0}, &chaincfg, chain)
+	cfg := rollup.Config{
+		IsVerifier: false,
+	}
+
+	service, err := rollup.NewSyncService(context.Background(), cfg, txPool, chain, db)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Cannot initialize syncservice: %w", err)
+	}
+
+	return service, chain, &db, nil
+}
+
+// makeBlockChain creates a deterministic chain of blocks rooted at parent.
+func makeBlockChain(parent *types.Block, n int, engine consensus.Engine, db ethdb.Database, seed int) []*types.Block {
+	blocks, _ := core.GenerateChain(params.TestChainConfig, parent, engine, db, n, func(i int, b *core.BlockGen) {
+		b.SetCoinbase(common.Address{0: byte(seed), 19: byte(i)})
+	})
+	return blocks
 }

--- a/eth/api_backend_test.go
+++ b/eth/api_backend_test.go
@@ -7,15 +7,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/consensus"
-	"github.com/ethereum/go-ethereum/consensus/ethash"
-	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/params"
-	"github.com/ethereum/go-ethereum/rollup"
 )
 
 func TestGasLimit(t *testing.T) {
@@ -49,74 +41,4 @@ func TestGasLimit(t *testing.T) {
 	if err.Error() != fmt.Sprintf("Transaction gasLimit (%d) is greater than max gasLimit (%d)", gasLimit, backend.GasLimit) {
 		t.Fatalf("Unexpected error type: %s", err)
 	}
-}
-
-func TestSetHead(t *testing.T) {
-	s, bc, db, err := newTestSyncService()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	backend := &EthAPIBackend{
-		eth: &Ethereum{
-			syncService: s,
-			blockchain:  bc,
-		},
-		UsingOVM: true,
-	}
-
-	// Insert a chain of 3
-	blocks := makeBlockChain(bc.CurrentBlock(), 3, ethash.NewFaker(), *db, 10)
-	_, err = bc.InsertChain(blocks)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Assert that the current block is height 3
-	current := backend.CurrentBlock()
-	if current.NumberU64() != 3 {
-		t.Fatal("Current doesn't match")
-	}
-
-	// Set the head to 1 and then make sure the tip is on 1
-	backend.SetHead(1)
-	current = backend.CurrentBlock()
-	if current.NumberU64() != 1 {
-		t.Fatal("Current doesn't match")
-	}
-}
-
-func newTestSyncService() (*rollup.SyncService, *core.BlockChain, *ethdb.Database, error) {
-	chainCfg := params.AllEthashProtocolChanges
-	chainID := big.NewInt(420)
-	chainCfg.ChainID = chainID
-
-	engine := ethash.NewFaker()
-	db := rawdb.NewMemoryDatabase()
-	_ = new(core.Genesis).MustCommit(db)
-	chain, err := core.NewBlockChain(db, nil, chainCfg, engine, vm.Config{}, nil)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("Cannot initialize blockchain: %w", err)
-	}
-	chaincfg := params.ChainConfig{ChainID: chainID}
-
-	txPool := core.NewTxPool(core.TxPoolConfig{PriceLimit: 0}, &chaincfg, chain)
-	cfg := rollup.Config{
-		IsVerifier: false,
-	}
-
-	service, err := rollup.NewSyncService(context.Background(), cfg, txPool, chain, db)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("Cannot initialize syncservice: %w", err)
-	}
-
-	return service, chain, &db, nil
-}
-
-// makeBlockChain creates a deterministic chain of blocks rooted at parent.
-func makeBlockChain(parent *types.Block, n int, engine consensus.Engine, db ethdb.Database, seed int) []*types.Block {
-	blocks, _ := core.GenerateChain(params.TestChainConfig, parent, engine, db, n, func(i int, b *core.BlockGen) {
-		b.SetCoinbase(common.Address{0: byte(seed), 19: byte(i)})
-	})
-	return blocks
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1966,6 +1966,10 @@ func (api *PrivateDebugAPI) SetHead(number hexutil.Uint64) {
 	api.b.SetHead(uint64(number))
 }
 
+func (api *PrivateDebugAPI) SetL1Head(number hexutil.Uint64) {
+	api.b.SetL1Head(uint64(number))
+}
+
 // PublicNetAPI offers network related RPC methods
 type PublicNetAPI struct {
 	net            *p2p.Server

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -92,6 +92,7 @@ type Backend interface {
 	GetRollupContractAddresses() map[string]*common.Address
 	GetLatestL1BlockNumber() uint64
 	GetLatestL1Timestamp() uint64
+	SetL1Head(number uint64)
 
 	ChainConfig() *params.ChainConfig
 	CurrentBlock() *types.Block

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -92,7 +92,7 @@ type Backend interface {
 	GetRollupContractAddresses() map[string]*common.Address
 	GetLatestL1BlockNumber() uint64
 	GetLatestL1Timestamp() uint64
-	SetL1Head(number uint64)
+	SetL1Head(number uint64) error
 
 	ChainConfig() *params.ChainConfig
 	CurrentBlock() *types.Block

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -91,6 +91,10 @@ func (b *LesApiBackend) SetHead(number uint64) {
 	b.eth.blockchain.SetHead(number)
 }
 
+func (b *LesApiBackend) SetL1Head(number uint64) {
+	panic("unimplemented")
+}
+
 func (b *LesApiBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	if number == rpc.LatestBlockNumber || number == rpc.PendingBlockNumber {
 		return b.eth.blockchain.CurrentHeader(), nil

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -91,7 +91,7 @@ func (b *LesApiBackend) SetHead(number uint64) {
 	b.eth.blockchain.SetHead(number)
 }
 
-func (b *LesApiBackend) SetL1Head(number uint64) {
+func (b *LesApiBackend) SetL1Head(number uint64) error {
 	panic("unimplemented")
 }
 

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -1308,6 +1308,7 @@ func (s *SyncService) SetL1Head(number uint64) error {
 		BlockHeight: header.Number.Uint64(),
 		BlockHash:   header.Hash(),
 	}
+	return nil
 }
 
 // Adds the transaction to the mempool so that downstream services

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -1288,14 +1288,15 @@ func (s *SyncService) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Sub
 
 // SetL1Head resets the Eth1Data
 // and the LatestL1BlockNumber and LatestL1Timestamp
-func (s *SyncService) SetL1Head(number uint64) {
-	var header *types.Header
-	var err error
-	for {
-		header, err = s.ethclient.HeaderByNumber(s.ctx, new(big.Int).SetUint64(number))
-		if err == nil {
-			break
-		}
+func (s *SyncService) SetL1Head(number uint64) error {
+	header, err := s.ethclient.HeaderByNumber(s.ctx, new(big.Int).SetUint64(number))
+	if err != nil {
+		return fmt.Errorf("Cannot fetch block in SetL1Head: %w", err)
+	}
+
+	// Reset the header cache
+	for i := 0; i < len(s.HeaderCache); i++ {
+		s.HeaderCache[i] = nil
 	}
 
 	// Reset the last synced L1 heights


### PR DESCRIPTION
## Description

Adds a new RPC endpoint `debug_setL1Head` that can be used to reset the tip of the `SyncService`'s L1 syncing process.
Also adds in resetting the `LatestL1{BlockNumber,Timestamp]` when calling `debug_setHead`. These can be used to recover from failures more easily.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.