### PR TITLE
syncservice: less requests when polling

### DIFF
--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -413,12 +413,15 @@ func (s *SyncService) pollHead() {
 			}
 			// We want to trail the tip by a confirmation number of blocks, so
 			// subtract the confirmationDepth from the tip height and fetch the
-			// block header that will be consumed.
-			blockNumber := head.Number.Sub(head.Number, new(big.Int).SetUint64(s.confirmationDepth))
-			head, err = s.ethclient.HeaderByNumber(s.ctx, blockNumber)
-			if err != nil {
-				log.Error("Cannot fetch tip", "height", blockNumber.Uint64())
-				continue
+			// block header that will be consumed. Only do this if the
+			// confirmation depth is more than 0
+			if s.confirmationDepth != 0 {
+				blockNumber := head.Number.Sub(head.Number, new(big.Int).SetUint64(s.confirmationDepth))
+				head, err = s.ethclient.HeaderByNumber(s.ctx, blockNumber)
+				if err != nil {
+					log.Error("Cannot fetch tip", "height", blockNumber.Uint64())
+					continue
+				}
 			}
 			// The tip is the same, do not ingest the block.
 			if bytes.Equal(head.Hash().Bytes(), s.Eth1Data.BlockHash.Bytes()) {


### PR DESCRIPTION
## Description

Saves sending requests when the confirmation depth is set to 0. This will help to reduce log clutter when running the integration tests. We cannot run with a confirmation depth of 0 on a public network until the reorg logic is well tested and implemented.
Replaces https://github.com/ethereum-optimism/go-ethereum/pull/170

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [ ] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.