### PR TITLE
gaslimit: fix eth_call

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -50,7 +50,7 @@ type EthAPIBackend struct {
 	gpo              *gasprice.Oracle
 	verifier         bool
 	DisableTransfers bool
-	GasLimit         uint64
+	gasLimit         uint64
 	UsingOVM         bool
 	MaxCallDataSize  int
 }
@@ -67,6 +67,10 @@ func (b *EthAPIBackend) IsVerifier() bool {
 
 func (b *EthAPIBackend) IsSyncing() bool {
 	return b.eth.syncService.IsSyncing()
+}
+
+func (b *EthAPIBackend) GasLimit() uint64 {
+	return b.gasLimit
 }
 
 func (b *EthAPIBackend) GetLatestEth1Data() (common.Hash, uint64) {
@@ -312,8 +316,8 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 			}
 
 			// Prevent transactions from being submitted if the gas limit too high
-			if signedTx.Gas() >= b.GasLimit {
-				return fmt.Errorf("Transaction gasLimit (%d) is greater than max gasLimit (%d)", signedTx.Gas(), b.GasLimit)
+			if signedTx.Gas() >= b.gasLimit {
+				return fmt.Errorf("Transaction gasLimit (%d) is greater than max gasLimit (%d)", signedTx.Gas(), b.gasLimit)
 			}
 
 			if b.DisableTransfers {

--- a/eth/api_backend_test.go
+++ b/eth/api_backend_test.go
@@ -17,7 +17,7 @@ func TestGasLimit(t *testing.T) {
 		gpo:              nil,
 		verifier:         false,
 		DisableTransfers: false,
-		GasLimit:         0,
+		gasLimit:         0,
 		UsingOVM:         true,
 	}
 
@@ -38,7 +38,7 @@ func TestGasLimit(t *testing.T) {
 	if err == nil {
 		t.Fatal("Transaction with too large of gas limit accepted")
 	}
-	if err.Error() != fmt.Sprintf("Transaction gasLimit (%d) is greater than max gasLimit (%d)", gasLimit, backend.GasLimit) {
+	if err.Error() != fmt.Sprintf("Transaction gasLimit (%d) is greater than max gasLimit (%d)", gasLimit, backend.GasLimit()) {
 		t.Fatalf("Unexpected error type: %s", err)
 	}
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -888,7 +888,7 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 		}
 	}
 	// Set default gas & gas price if none were set
-	gas := uint64(12000000)
+	gas := b.GasLimit()
 	if args.Gas != nil {
 		gas = uint64(*args.Gas)
 	}

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -93,6 +93,7 @@ type Backend interface {
 	GetLatestL1BlockNumber() uint64
 	GetLatestL1Timestamp() uint64
 	SetL1Head(number uint64) error
+	GasLimit() uint64
 
 	ChainConfig() *params.ChainConfig
 	CurrentBlock() *types.Block

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -54,6 +54,10 @@ func (b *LesApiBackend) IsVerifier() bool {
 	return false
 }
 
+func (b *LesApiBackend) GasLimit() uint64 {
+	panic("not implemented")
+}
+
 func (b *LesApiBackend) IsSyncing() bool {
 	return false
 }


### PR DESCRIPTION
## Description

Removes the hardcoded gas limit and will instead use the gas limit that is passed via configuration

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.