### PR TITLE
config: genesis state flags

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -163,10 +163,12 @@ var (
 		// Enable verifier mode
 		utils.RollupEnableVerifierFlag,
 		utils.RollupAddressManagerOwnerAddressFlag,
+		utils.RollupAllowArbitraryContractDeploymentFlag,
 		utils.RollupStateDumpPathFlag,
 		utils.RollupDiffDbFlag,
 		utils.RollupDisableTransfersFlag,
 		utils.RollupMaxCalldataSizeFlag,
+		utils.RollupAllowArbitraryContractDeploymentFlag,
 	}
 
 	rpcFlags = []cli.Flag{

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -75,11 +75,13 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.Eth1NetworkIdFlag,
 			utils.Eth1HTTPFlag,
 			utils.RollupAddressManagerOwnerAddressFlag,
+			utils.RollupAllowArbitraryContractDeploymentFlag,
 			utils.RollupEnableVerifierFlag,
 			utils.RollupStateDumpPathFlag,
 			utils.RollupDiffDbFlag,
 			utils.RollupDisableTransfersFlag,
 			utils.RollupMaxCalldataSizeFlag,
+			utils.RollupAllowArbitraryContractDeploymentFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -853,6 +853,17 @@ var (
 		Value:  "0x0000000000000000000000000000000000000000",
 		EnvVar: "ROLLUP_ADDRESS_MANAGER_OWNER_ADDRESS",
 	}
+	RollupDeployWhitelistOwnerAddressFlag = cli.StringFlag{
+		Name:   "rollup.rollupdeploywhitelistowneraddress",
+		Usage:  "Owner of the deployment whitelist",
+		Value:  "0x0000000000000000000000000000000000000000",
+		EnvVar: "ROLLUP_DEPLOYMENT_WHITELIST_OWNER_ADDRESS",
+	}
+	RollupAllowArbitraryContractDeploymentFlag = cli.BoolFlag{
+		Name:   "rollup.allowarbitrarycontractdeployment",
+		Usage:  "Enable arbitrary contract deployment",
+		EnvVar: "ROLLUP_ALLOW_ARBITRARY_CONTRACT_DEPLOYMENT",
+	}
 	RollupStateDumpPathFlag = cli.StringFlag{
 		Name:   "rollup.statedumppath",
 		Usage:  "Path to the state dump",
@@ -1179,6 +1190,13 @@ func setRollup(ctx *cli.Context, cfg *rollup.Config) {
 	}
 	if ctx.GlobalIsSet(RollupMaxCalldataSizeFlag.Name) {
 		cfg.MaxCallDataSize = ctx.GlobalInt(RollupMaxCalldataSizeFlag.Name)
+	}
+	if ctx.GlobalIsSet(RollupDeployWhitelistOwnerAddressFlag.Name) {
+		addr := ctx.GlobalString(RollupDeployWhitelistOwnerAddressFlag.Name)
+		cfg.DeployWhitelistOwnerAddress = addr
+	}
+	if ctx.GlobalIsSet(RollupAllowArbitraryContractDeploymentFlag.Name) {
+		cfg.AllowArbitraryContractDeployment = true
 	}
 }
 
@@ -1745,8 +1763,10 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 		}
 		xdomainAddress := cfg.Rollup.L1CrossDomainMessengerAddress
 		addrManagerOwnerAddress := cfg.Rollup.AddressManagerOwnerAddress
+		deployWhitelistOwnerAddress := cfg.Rollup.DeployWhitelistOwnerAddress
+		allowArbitraryContractDeployment := cfg.Rollup.AllowArbitraryContractDeployment
 		stateDumpPath := cfg.Rollup.StateDumpPath
-		cfg.Genesis = core.DeveloperGenesisBlock(uint64(ctx.GlobalInt(DeveloperPeriodFlag.Name)), developer.Address, xdomainAddress, addrManagerOwnerAddress, stateDumpPath, chainID, gasLimit)
+		cfg.Genesis = core.DeveloperGenesisBlock(uint64(ctx.GlobalInt(DeveloperPeriodFlag.Name)), developer.Address, xdomainAddress, addrManagerOwnerAddress, deployWhitelistOwnerAddress, stateDumpPath, chainID, gasLimit, allowArbitraryContractDeployment)
 		if !ctx.GlobalIsSet(MinerGasPriceFlag.Name) && !ctx.GlobalIsSet(MinerLegacyGasPriceFlag.Name) {
 			cfg.Miner.GasPrice = big.NewInt(1)
 		}

--- a/rollup/config.go
+++ b/rollup/config.go
@@ -8,7 +8,6 @@ import (
 )
 
 type Config struct {
-	// TODO(mark): deprecate these config options
 	TxIngestionEnable bool
 	// Maximum calldata size for a Queue Origin Sequencer Tx
 	MaxCallDataSize int
@@ -34,6 +33,8 @@ type Config struct {
 	SequencerDecompressionAddress    common.Address
 	L1CrossDomainMessengerAddress    common.Address
 	AddressManagerOwnerAddress       common.Address
+	DeployWhitelistOwnerAddress      common.Address
+	AllowArbitraryContractDeployment bool
 	// Deployment Height of the canonical transaction chain
 	CanonicalTransactionChainDeployHeight *big.Int
 	// Path to the state dump


### PR DESCRIPTION
## Description

Adds two new config flags that set values into the genesis state
- `ROLLUP_DEPLOYMENT_WHITELIST_OWNER_ADDRESS`
- `ROLLUP_ALLOW_ARBITRARY_CONTRACT_DEPLOYEMENT`

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [ ] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.