### PR TITLE
syncservice: delete polling loop

### DIFF
--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -31,7 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-const headerCacheSize = 2048
+const headerCacheSize = 128
 
 // Interface used for communicating with Ethereum 1 nodes
 type EthereumClient interface {
@@ -331,6 +331,7 @@ func (s *SyncService) Start() error {
 	}
 	s.gasLimit = gasLimit.Uint64()
 	log.Info("Setting max transaction gas limit", "gas limit", s.gasLimit)
+	s.setSyncStatus(false)
 
 	go s.Loop()
 	go s.pollHead()
@@ -394,6 +395,7 @@ func (s *SyncService) getCommonAncestor(index *big.Int, list *[]*types.Header) (
 }
 
 func (s *SyncService) pollHead() {
+	log.Info("Starting poll head loop")
 	headTicker := time.NewTicker(time.Second * 10)
 	for {
 		select {

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -127,19 +127,36 @@ while (( "$#" )); do
     esac
 done
 
+CHAIN_ID=10
+NETWORK_ID=10
+ADDRESS_RESOLVER_ADDRESS=0x1De8CFD4C1A486200286073aE91DE6e8099519f1
+ETH1_CHAIN_ID=1
+ETH1_CONFIRMATION_DEPTH=20
+ETH1_CTC_DEPLOYMENT_HEIGHT=11650235
+ETH1_HTTP=https://eth-mainnet.alchemyapi.io/v2/FNlLpiCGqIUoxhz1ilNk5dOCN39qgDJF
+ETH1_L1_CROSS_DOMAIN_MESSENGER_ADDRESS=0x0AEBf5161A9b57349747D078c6763a0B1d67D888
+ETH1_NETWORK_ID=1
+L1_NODE_WEB3_URL=https://eth-mainnet.alchemyapi.io/v2/FNlLpiCGqIUoxhz1ilNk5dOCN39qgDJF
+ADDRESS_MANAGER_OWNER_ADDRESS=0xc6Dbc2DC7649c7d4292d955DA08A7C21a21e1528
+ROLLUP_STATE_DUMP_PATH=https://raw.githubusercontent.com/ethereum-optimism/regenesis/master/mainnet/1.json
+TARGET_GAS_LIMIT=9000000
+
 cmd="$REPO/build/bin/geth"
 cmd="$cmd --eth1.syncservice"
 cmd="$cmd --datadir $HOME/.ethereum"
 cmd="$cmd --eth1.http $ETH1_HTTP"
-cmd="$cmd --eth1.confirmationdepth 0"
+cmd="$cmd --eth1.confirmationdepth $ETH1_CONFIRMATION_DEPTH"
 cmd="$cmd --eth1.networkid $ETH1_NETWORK_ID"
 cmd="$cmd --eth1.chainid $ETH1_CHAIN_ID"
 cmd="$cmd --eth1.l1crossdomainmessengeraddress $L1_CROSS_DOMAIN_MESSENGER_ADDRESS"
 cmd="$cmd --eth1.addressresolveraddress $ADDRESS_RESOLVER_ADDRESS"
 cmd="$cmd --rollup.addressmanagerowneraddress $ADDRESS_MANAGER_OWNER_ADDRESS"
+cmd="$cmd --rollup.statedumppath $ROLLUP_STATE_DUMP_PATH"
 cmd="$cmd --eth1.ctcdeploymentheight $ETH1_CTC_DEPLOYMENT_HEIGHT"
 cmd="$cmd --rpc"
 cmd="$cmd --dev"
+cmd="$cmd --networkid $NETWORK_ID"
+cmd="$cmd --chainid $CHAIN_ID"
 cmd="$cmd --rpcaddr 0.0.0.0"
 cmd="$cmd --rpccorsdomain '*'"
 cmd="$cmd --wsaddr 0.0.0.0"
@@ -157,4 +174,4 @@ if [ ! -z "$IS_VERIFIER" ]; then
 fi
 
 echo -e "Running:\n$cmd"
-eval env TARGET_GAS_LIMIT=$TARGET_GAS_LIMIT USING_OVM=true $cmd
+eval env TARGET_GAS_LIMIT=$TARGET_GAS_LIMIT USING_OVM=true $cmd --verbosity=6


### PR DESCRIPTION
## Description

Deletes the `sequencerIngestQueue` function in the sync service. It was originally used to apply transactions , be we moved to a model where L1 blocks trigger transaction application. This makes the sync service much more deterministic.

Do not merge yet, pending testing

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.