### PR TITLE
syncservice: reduce headercache size to 32

### DIFF
--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -31,7 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-const headerCacheSize = 2048
+const headerCacheSize = 32
 
 // Interface used for communicating with Ethereum 1 nodes
 type EthereumClient interface {


### PR DESCRIPTION
## Description

Reduces the `headerCacheSize` to 32

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.