### PR TITLE
bugfix: setl1head

### DIFF
--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -1301,6 +1301,8 @@ func (s *SyncService) SetL1Head(number uint64) error {
 	for i := 0; i < len(s.HeaderCache); i++ {
 		s.HeaderCache[i] = nil
 	}
+	// Be sure to add the header to the cache
+	s.HeaderCache[header.Number.Uint64()%headerCacheSize] = header
 
 	// Reset the last synced L1 heights
 	rawdb.WriteHeadEth1HeaderHash(s.db, header.Hash())


### PR DESCRIPTION
## Description

Quick bugfix for `debug_setL1Head`. Without this fix, after calling this method geth will recursively query the L1 provider back until the configured ctc deploy height.

The headercache needs a refactor with nice getters and setters

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.