### PR TITLE
rpc: debug_ingestTransactions

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -130,7 +130,7 @@ func (b *EthAPIBackend) SetHead(number uint64) {
 
 func (b *EthAPIBackend) IngestTransactions(txs []*types.Transaction) error {
 	for _, tx := range txs {
-		err := b.eth.syncService.ApplyTransaction(tx)
+		err := b.eth.syncService.IngestTransaction(tx)
 		if err != nil {
 			return err
 		}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -128,6 +128,16 @@ func (b *EthAPIBackend) SetHead(number uint64) {
 	b.eth.syncService.SetLatestL1BlockNumber(blockNumber.Uint64())
 }
 
+func (b *EthAPIBackend) IngestTransactions(txs []*types.Transaction) error {
+	for _, tx := range txs {
+		err := b.eth.syncService.ApplyTransaction(tx)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
 	// Pending block is only known by the miner
 	if number == rpc.PendingBlockNumber {

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -90,7 +90,7 @@ type Backend interface {
 	GetEthContext() (uint64, uint64)
 	GetRollupContext() (uint64, uint64)
 	GasLimit() uint64
-
+	IngestTransactions([]*types.Transaction) error
 	ChainConfig() *params.ChainConfig
 	CurrentBlock() *types.Block
 

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -58,16 +58,20 @@ func (b *LesApiBackend) GetEthContext() (uint64, uint64) {
 	return 0, 0
 }
 
-func (b *LesApiBackend) GetRollupContext() (uint64, uint64) {
-	return 0, 0
-}
-
 func (b *LesApiBackend) IsSyncing() bool {
 	return false
 }
 
+func (b *LesApiBackend) IngestTransactions([]*types.Transaction) error {
+	panic("not implemented")
+}
+
 func (b *LesApiBackend) GetLatestEth1Data() (common.Hash, uint64) {
 	return common.Hash{}, 0
+}
+
+func (b *LesApiBackend) GetRollupContext() (uint64, uint64) {
+	return 0, 0
 }
 
 func (b *LesApiBackend) ChainConfig() *params.ChainConfig {

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -601,6 +601,10 @@ func (s *SyncService) applyTransaction(tx *types.Transaction) error {
 	return nil
 }
 
+func (s *SyncService) IngestTransaction(tx *types.Transaction) error {
+	return s.applyTransaction(tx)
+}
+
 // Higher level API for applying transactions. Should only be called for
 // queue origin sequencer transactions, as the contracts on L1 manage the same
 // validity checks that are done here.


### PR DESCRIPTION
## Description

Adds a new rpc endpoint `debug_ingestTransactions` that takes a list of JSON RPC Transactions and applies them to the state. This will enable the creation of a deterministic state in geth via RPC. The `debug` RPC namespace must not be made public. Data to ingest can be collected by using `eth_getBlockByNumber` with the second param set to true so that it returns the full JSON of a tx. It is expected that JSON with the same keys is sent. Note that the same chainid settings must be configured locally as the remote node, which makes this unsafe when it comes to replay protection. If you ingest mainnet in this way, do not send transactions against it that you would not want to be replayed.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.