### PR TITLE
miner: fill in index when missing

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -878,6 +878,17 @@ func (w *worker) commitNewTx(tx *types.Transaction) error {
 	timestamp := tx.L1Timestamp()
 
 	num := parent.Number()
+	// Fill in the index field in the tx meta if it is `nil`.
+	// This should only ever happen in the case of the sequencer
+	// receiving a queue origin sequencer transaction. The verifier
+	// should always receive transactions with an index as they
+	// have already been confirmed in the canonical transaction chain.
+	// Use the parent's block number because the CTC is 0 indexed.
+	if meta := tx.GetMeta(); meta.Index == nil {
+		index := num.Uint64()
+		meta.Index = &index
+		tx.SetTransactionMeta(meta)
+	}
 	header := &types.Header{
 		ParentHash: parent.Hash(),
 		Number:     num.Add(num, common.Big1),


### PR DESCRIPTION
## Description

This PR inserts the `Index` into the `TransactionMeta` if it is not present. This should only happen in the case of the sequencer when there is a queue origin sequencer transaction that has not been confirmed into the CTC

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.