### PR TITLE
syncservice: fix historical syncing bug

### DIFF
--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -450,7 +450,7 @@ func (s *SyncService) syncTransactionsToTip() error {
 		index := rawdb.ReadHeadIndex(s.db)
 		start := uint64(0)
 		if index != nil {
-			start = *index
+			start = *index + 1
 		}
 
 		log.Info("Syncing transactions to tip", "start", start, "end", *tipHeight)


### PR DESCRIPTION
## Description

Fixes a historical sync issue where it will double play the last tx

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.