### PR TITLE
feat: new eth call

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -206,7 +206,9 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, failed bo
 
 	if vm.UsingOVM {
 		// OVM_ENABLED
-		st.msg, err = toExecutionManagerRun(st.evm, st.msg)
+		if st.evm.EthCallSender == nil {
+			st.msg, err = toExecutionManagerRun(st.evm, st.msg)
+		}
 		st.data = st.msg.Data()
 		if err != nil {
 			return nil, 0, false, err

--- a/core/state_transition_ovm.go
+++ b/core/state_transition_ovm.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/rollup/dump"
 )
 
 var ZeroAddress = common.HexToAddress("0x0000000000000000000000000000000000000000")
@@ -134,19 +134,10 @@ func asOvmMessage(tx *types.Transaction, signer types.Signer, decompressor commo
 	return outmsg, nil
 }
 
-func EncodeFakeMessage(
-	msg Message,
-	account abi.ABI,
-) (Message, error) {
-	// var input = []interface{}{
-	// 	big.NewInt(int64(msg.Gas())),
-	// 	msg.To(),
-	// 	msg.Data(),
-	// }
-
+func EncodeSimulatedMessage(msg Message, timestamp, blockNumber *big.Int, executionManager, stateManager dump.OvmDumpAccount) (Message, error) {
 	tx := ovmTransaction{
-		evm.Context.Time,
-		evm.Context.BlockNumber, // TODO (what's the correct block number?)
+		timestamp,
+		blockNumber, // TODO (what's the correct block number?)
 		uint8(msg.QueueOrigin().Uint64()),
 		*msg.L1MessageSender(),
 		*msg.To(),
@@ -154,24 +145,22 @@ func EncodeFakeMessage(
 		msg.Data(),
 	}
 
-	var abi = evm.Context.OvmExecutionManager.ABI
+	from := msg.From()
 	var args = []interface{}{
 		tx,
-		evm.Context.OvmStateManager.Address,
+		from,
+		stateManager.Address,
 	}
 
-	ret, err := abi.Pack("run", args...)
+	output, err := executionManager.ABI.Pack("simulateMessage", args...)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot pack simulateMessage: %w", err)
+	}
 
-	// output, err := account.Pack("qall", input...)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	from := msg.From()
 	return modMessage(
 		msg,
-		from,
-		&from,
+		common.Address{},
+		&executionManager.Address,
 		output,
 		msg.Gas(),
 	)

--- a/core/state_transition_ovm.go
+++ b/core/state_transition_ovm.go
@@ -138,16 +138,34 @@ func EncodeFakeMessage(
 	msg Message,
 	account abi.ABI,
 ) (Message, error) {
-	var input = []interface{}{
+	// var input = []interface{}{
+	// 	big.NewInt(int64(msg.Gas())),
+	// 	msg.To(),
+	// 	msg.Data(),
+	// }
+
+	tx := ovmTransaction{
+		evm.Context.Time,
+		evm.Context.BlockNumber, // TODO (what's the correct block number?)
+		uint8(msg.QueueOrigin().Uint64()),
+		*msg.L1MessageSender(),
+		*msg.To(),
 		big.NewInt(int64(msg.Gas())),
-		msg.To(),
 		msg.Data(),
 	}
 
-	output, err := account.Pack("qall", input...)
-	if err != nil {
-		return nil, err
+	var abi = evm.Context.OvmExecutionManager.ABI
+	var args = []interface{}{
+		tx,
+		evm.Context.OvmStateManager.Address,
 	}
+
+	ret, err := abi.Pack("run", args...)
+
+	// output, err := account.Pack("qall", input...)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
 	from := msg.From()
 	return modMessage(

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -49,7 +49,6 @@ type (
 
 // run runs the given contract and takes care of running precompiles with a fallback to the byte code interpreter.
 func run(evm *EVM, contract *Contract, input []byte, readOnly bool) ([]byte, error) {
-	log.Debug("run with gas", "gas", contract.Gas)
 	if UsingOVM {
 		// OVM_ENABLED
 
@@ -89,8 +88,6 @@ func run(evm *EVM, contract *Contract, input []byte, readOnly bool) ([]byte, err
 			return callStateManager(input, evm, contract)
 		}
 	}
-
-	log.Debug("Not calling state manager", "addr", contract.Address(), "caller", contract.Caller().Hex(), "input", hexutil.Encode(input))
 
 	if contract.CodeAddr != nil {
 		precompiles := PrecompiledContractsHomestead

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -70,7 +70,7 @@ func run(evm *EVM, contract *Contract, input []byte, readOnly bool) ([]byte, err
 
 		// We don't know the contract, so print some generic information.
 		if isUnknown {
-			log.Debug("Calling Unknown Contract", "Address", contract.Address().Hex(), "data", hexutil.Encode(input))
+			log.Debug("Calling Unknown Contract", "Address", contract.Address().Hex())
 		}
 
 		// Uncomment to make Safety checker always returns true.
@@ -98,11 +98,7 @@ func run(evm *EVM, contract *Contract, input []byte, readOnly bool) ([]byte, err
 			precompiles = PrecompiledContractsIstanbul
 		}
 		if p := precompiles[*contract.CodeAddr]; p != nil {
-			result, err := RunPrecompiledContract(p, input, contract)
-			if err != nil {
-				log.Debug("Error running precompile")
-			}
-			return result, err
+			return RunPrecompiledContract(p, input, contract)
 		}
 	}
 
@@ -279,7 +275,6 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 			evm.Context.OriginalTargetAddress == nil {
 			// Whew. Okay, so: we consider ourselves to be at a "target" as long as we were called
 			// by the execution manager, and we're not a precompile or "dead" address.
-			log.Info("target set", "addr", addr.Hex())
 			evm.Context.OriginalTargetAddress = &addr
 			evm.Context.OriginalTargetReached = true
 			isTarget = true
@@ -355,9 +350,6 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	}
 
 	ret, err = run(evm, contract, input, false)
-	if err != nil {
-		log.Debug("run error not nil", "error", err)
-	}
 
 	// When an error was returned by the EVM or when setting the creation code
 	// above we revert to the snapshot and consume any gas remaining. Additionally
@@ -394,7 +386,6 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 				// empty.
 				success := evm.Context.OriginalTargetResult[:32]
 				ret = evm.Context.OriginalTargetResult[96:]
-				log.Debug("ret", "data", hexutil.Encode(evm.Context.OriginalTargetResult))
 
 				if !bytes.Equal(success, AbiBytesTrue) && !bytes.Equal(success, AbiBytesFalse) {
 					// If the first 32 bytes not either are the ABI encoding of "true" or "false",

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -278,7 +278,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 		if caller.Address() == evm.Context.OvmExecutionManager.Address &&
 			!strings.HasPrefix(strings.ToLower(addr.Hex()), "0xdeaddeaddeaddeaddeaddeaddeaddeaddead") &&
 			!strings.HasPrefix(strings.ToLower(addr.Hex()), "0x000000000000000000000000000000000000") &&
-			// !strings.HasPrefix(strings.ToLower(addr.Hex()), "0x420000000000000000000000000000000000") &&
+			!strings.HasPrefix(strings.ToLower(addr.Hex()), "0x420000000000000000000000000000000000") &&
 			evm.Context.OriginalTargetAddress == nil {
 			// Whew. Okay, so: we consider ourselves to be at a "target" as long as we were called
 			// by the execution manager, and we're not a precompile or "dead" address.

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -322,33 +322,33 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 		evm.Transfer(evm.StateDB, caller.Address(), to.Address(), value)
 	}
 
-	var prevCode []byte
-	if UsingOVM {
-		// OVM_ENABLED
-		if evm.Context.EthCallSender != nil && *evm.Context.EthCallSender == addr {
-			// We have to handle eth_call in a special manner as it doesn't stem from a signed
-			// transaction and therefore can't go through the standard EOA contract. When we detect
-			// this case, we temporarily insert some mock code that allows the user to pass through
-			// the EOA without a signature. EthCallSender should *never* be made non-nil outside
-			// of an eth_call. We store the old code here so that we're able to reset the code to
-			// the original code for the remainder of the transaction.
-			prevCode = evm.StateDB.GetCode(addr)
-			evm.StateDB.SetCode(addr, common.FromHex(evm.Context.OvmMockAccount.Code))
-		}
-	}
+	// var prevCode []byte
+	// if UsingOVM {
+	// 	// OVM_ENABLED
+	// 	if evm.Context.EthCallSender != nil && *evm.Context.EthCallSender == addr {
+	// 		// We have to handle eth_call in a special manner as it doesn't stem from a signed
+	// 		// transaction and therefore can't go through the standard EOA contract. When we detect
+	// 		// this case, we temporarily insert some mock code that allows the user to pass through
+	// 		// the EOA without a signature. EthCallSender should *never* be made non-nil outside
+	// 		// of an eth_call. We store the old code here so that we're able to reset the code to
+	// 		// the original code for the remainder of the transaction.
+	// 		prevCode = evm.StateDB.GetCode(addr)
+	// 		evm.StateDB.SetCode(addr, common.FromHex(evm.Context.OvmMockAccount.Code))
+	// 	}
+	// }
 
 	// Initialise a new contract and set the code that is to be used by the EVM.
 	// The contract is a scoped environment for this execution context only.
 	contract := NewContract(caller, to, value, gas)
 	contract.SetCallCode(&addr, evm.StateDB.GetCodeHash(addr), evm.StateDB.GetCode(addr))
 
-	if UsingOVM {
-		// OVM_ENABLED
-		if evm.Context.EthCallSender != nil && *evm.Context.EthCallSender == addr {
-			// Reset the code once it's been loaded into the contract object.
-			evm.StateDB.SetCode(addr, prevCode)
-		}
-	}
+	// if UsingOVM {
+	// 	// OVM_ENABLED
+	// 	if evm.Context.EthCallSender != nil && *evm.Context.EthCallSender == addr {
+	// 		// Reset the code once it's been loaded into the contract object.
+	// 		evm.StateDB.SetCode(addr, prevCode)
+	// 	}
+	// }
 
 	// Even if the account has no code, we need to continue because it might be a precompile
 	start := time.Now()

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -18,7 +18,6 @@ package vm
 
 import (
 	"bytes"
-	"fmt"
 	"math/big"
 	"strconv"
 	"strings"
@@ -112,11 +111,7 @@ func run(evm *EVM, contract *Contract, input []byte, readOnly bool) ([]byte, err
 				}(evm.interpreter)
 				evm.interpreter = interpreter
 			}
-			result, err := interpreter.Run(contract, input, readOnly)
-			if err != nil {
-				return result, fmt.Errorf("cannot run interpreter: %w", err)
-			}
-			return result, err
+			return interpreter.Run(contract, input, readOnly)
 		}
 	}
 

--- a/core/vm/ovm_state_manager.go
+++ b/core/vm/ovm_state_manager.go
@@ -39,7 +39,7 @@ func callStateManager(input []byte, evm *EVM, contract *Contract) (ret []byte, e
 
 	method, err := abi.MethodById(input)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot find method id %s: %w", input, err)
 	}
 
 	var inputArgs = make(map[string]interface{})
@@ -55,12 +55,12 @@ func callStateManager(input []byte, evm *EVM, contract *Contract) (ret []byte, e
 
 	outputArgs, err := fn(evm, contract, inputArgs)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot execute state manager function: %w", err)
 	}
 
 	returndata, err := method.Outputs.PackValues(outputArgs)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cannot pack returndata: %w", err)
 	}
 
 	return returndata, nil

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -945,9 +945,12 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 	msg = types.NewMessage(addr, args.To, 0, value, gas, gasPrice, data, false, &addr, nil, types.QueueOriginSequencer, 0)
 	if vm.UsingOVM {
 		cfg := b.ChainConfig()
-		account := cfg.StateDump.Accounts["OVM_ExecutionManager"].ABI
+		executionManager := cfg.StateDump.Accounts["OVM_ExecutionManager"]
+		stateManager := cfg.StateDump.Accounts["OVM_StateManager"]
 		var err error
-		msg, err = core.EncodeFakeMessage(msg, account)
+		blockNumber := header.Number
+		timestamp := new(big.Int).SetUint64(header.Time)
+		msg, err = core.EncodeSimulatedMessage(msg, timestamp, blockNumber, executionManager, stateManager)
 		if err != nil {
 			return nil, 0, false, err
 		}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -945,7 +945,7 @@ func DoCall(ctx context.Context, b Backend, args CallArgs, blockNrOrHash rpc.Blo
 	msg = types.NewMessage(addr, args.To, 0, value, gas, gasPrice, data, false, &addr, nil, types.QueueOriginSequencer, 0)
 	if vm.UsingOVM {
 		cfg := b.ChainConfig()
-		account := cfg.StateDump.Accounts["mockOVM_ECDSAContractAccount"].ABI
+		account := cfg.StateDump.Accounts["OVM_ExecutionManager"].ABI
 		var err error
 		msg, err = core.EncodeFakeMessage(msg, account)
 		if err != nil {

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -151,13 +151,13 @@ func NewSyncService(ctx context.Context, cfg Config, txpool *core.TxPool, bc *co
 			q = strconv.FormatUint(*queueIndex, 10)
 		}
 		log.Info("Initialized Eth Context", "index", i, "queue-index", q)
-	}
 
-	// The sequencer needs to sync to the tip at start up
-	// By setting the sync status to true, it will prevent RPC calls.
-	// Be sure this is set to false later.
-	if !service.verifier {
-		service.setSyncStatus(true)
+		// The sequencer needs to sync to the tip at start up
+		// By setting the sync status to true, it will prevent RPC calls.
+		// Be sure this is set to false later.
+		if !service.verifier {
+			service.setSyncStatus(true)
+		}
 	}
 
 	return &service, nil

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -173,7 +173,7 @@ while (( "$#" )); do
 done
 
 cmd="$REPO/build/bin/geth"
-cmd="$cmd --eth1.syncservice"
+# cmd="$cmd --eth1.syncservice"
 cmd="$cmd --datadir $DATADIR"
 cmd="$cmd --eth1.chainid $ETH1_CHAIN_ID"
 cmd="$cmd --eth1.l1crossdomainmessengeraddress $ETH1_L1_CROSS_DOMAIN_MESSENGER_ADDRESS"
@@ -189,6 +189,7 @@ cmd="$cmd --dev"
 cmd="$cmd --chainid $CHAIN_ID"
 cmd="$cmd --rpcaddr 0.0.0.0"
 cmd="$cmd --rpcport $RPC_PORT"
+cmd="$cmd --rpcvhosts '*'"
 cmd="$cmd --rpccorsdomain '*'"
 cmd="$cmd --wsaddr 0.0.0.0"
 cmd="$cmd --wsport 8546"
@@ -203,4 +204,4 @@ if [[ ! -z "$IS_VERIFIER" ]]; then
 fi
 
 echo -e "Running:\n$cmd"
-eval env TARGET_GAS_LIMIT=$TARGET_GAS_LIMIT USING_OVM=true $cmd --verbosity=3
+eval env TARGET_GAS_LIMIT=$TARGET_GAS_LIMIT USING_OVM=true $cmd --verbosity=6

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -173,7 +173,7 @@ while (( "$#" )); do
 done
 
 cmd="$REPO/build/bin/geth"
-# cmd="$cmd --eth1.syncservice"
+cmd="$cmd --eth1.syncservice"
 cmd="$cmd --datadir $DATADIR"
 cmd="$cmd --eth1.chainid $ETH1_CHAIN_ID"
 cmd="$cmd --eth1.l1crossdomainmessengeraddress $ETH1_L1_CROSS_DOMAIN_MESSENGER_ADDRESS"
@@ -204,4 +204,4 @@ if [[ ! -z "$IS_VERIFIER" ]]; then
 fi
 
 echo -e "Running:\n$cmd"
-eval env TARGET_GAS_LIMIT=$TARGET_GAS_LIMIT USING_OVM=true $cmd --verbosity=6
+eval env TARGET_GAS_LIMIT=$TARGET_GAS_LIMIT USING_OVM=true $cmd --verbosity=3


### PR DESCRIPTION
## Description

Adds the new `eth_call` that uses the execution manager `simulateMessage()`
Must be used with the contracts found here: https://github.com/ethereum-optimism/contracts-v2/pull/238

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [ ] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.