### PR TITLE
msg: use zero address

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -332,7 +332,8 @@ func (tx *Transaction) AsMessage(s Signer) (Message, error) {
 	if tx.meta.L1MessageSender != nil {
 		msg.l1MessageSender = tx.meta.L1MessageSender
 	} else {
-		msg.l1MessageSender = &msg.from // TODO: Zero address
+		addr := common.Address{}
+		msg.l1MessageSender = &addr
 	}
 
 	return msg, err


### PR DESCRIPTION
## Description

Use the zero address for `L1MessageSender`

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.