### PR TITLE
[Fix] Run integration tests in forked context

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,8 +28,9 @@ jobs:
               GITHUB_HEAD_REF=${GITHUB_REF##*/}
           fi
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
+          REMOTE=${{ github.event.pull_request.head.repo.html_url }}
           echo "optimism-integration $GIT_COMMIT"
-          ./docker/build.sh -s go-ethereum -b $GITHUB_HEAD_REF -r ${{ github.event.pull_request.head.repo.html_url }}
+          ./docker/build.sh -s go-ethereum -b $GITHUB_HEAD_REF -r $REMOTE
 
       - name: Test
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,7 +29,7 @@ jobs:
           fi
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
           echo "optimism-integration $GIT_COMMIT"
-          ./docker/build.sh -s go-ethereum -b $GITHUB_HEAD_REF
+          ./docker/build.sh -s go-ethereum -b $GITHUB_HEAD_REF -r ${{ github.event.pull_request.head.repo.html_url }}
 
       - name: Test
         run: |


### PR DESCRIPTION
## Description

Addresses ethereum-optimism/roadmap#643

This PR attempts to move the CI logic to run in the forked context instead of in our home repo.

## Questions
- 
-
-

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [ ] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.