### PR TITLE
Fix WETH Typo

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -301,7 +301,7 @@ func ApplyOvmStateToState(statedb *state.StateDB, stateDump *dump.OvmDump, l1XDo
 	OVM_ETH, ok := stateDump.Accounts["OVM_ETH"]
 	if ok {
 		// Set the gateway of OVM_ETH
-		log.Info("Setting OVM_L1WETHGateway in OVM_ETH", "address", l1ETHGatewayAddress.Hex())
+		log.Info("Setting OVM_L1ETHGateway in OVM_ETH", "address", l1ETHGatewayAddress.Hex())
 		l1GatewaySlot := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000008")
 		l1GatewayValue := common.BytesToHash(l1ETHGatewayAddress.Bytes())
 		statedb.SetState(OVM_ETH.Address, l1GatewaySlot, l1GatewayValue)


### PR DESCRIPTION
## Description

As seen on geohot's recent stream there is a minor typo describing the ETH deposit gateway as a WETH deposit gateway. This PR removes the letter `W`.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.