### PR TITLE
rollup: don't segfault on historical sync

### DIFF
--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -225,7 +225,7 @@ func (s *SyncService) initializeLatestL1(ctcDeployHeight *big.Int) error {
 			block = s.bc.CurrentBlock()
 			idx := block.Number().Uint64()
 			s.SetLatestIndex(&idx)
-			log.Info("Block not found, resetting index", "new", idx, "old", *index)
+			log.Info("Block not found, resetting index", "new", idx, "old", *index-1)
 		}
 		txs := block.Transactions()
 		if len(txs) != 1 {

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -221,6 +221,12 @@ func (s *SyncService) initializeLatestL1(ctcDeployHeight *big.Int) error {
 	} else {
 		log.Info("Found latest index", "index", *index)
 		block := s.bc.GetBlockByNumber(*index - 1)
+		if block == nil {
+			block = s.bc.CurrentBlock()
+			idx := block.Number().Uint64()
+			s.SetLatestIndex(&idx)
+			log.Info("Block not found, resetting index", "new", idx, "old", *index)
+		}
 		txs := block.Transactions()
 		if len(txs) != 1 {
 			log.Error("Unexpected number of transactions in block: %d", len(txs))

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -224,6 +224,10 @@ func (s *SyncService) initializeLatestL1(ctcDeployHeight *big.Int) error {
 		if block == nil {
 			block = s.bc.CurrentBlock()
 			idx := block.Number().Uint64()
+			if idx > *index {
+				// This is recoverable with a reorg
+				return fmt.Errorf("Current block height greater than index")
+			}
 			s.SetLatestIndex(&idx)
 			log.Info("Block not found, resetting index", "new", idx, "old", *index-1)
 		}


### PR DESCRIPTION
## Description

Replaces https://github.com/ethereum-optimism/go-ethereum/pull/229
This prevents a segfault when stopping syncing during the historical sync

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.