### PR TITLE
config: use max possible max calldata size

### DIFF
--- a/eth/config.go
+++ b/eth/config.go
@@ -63,8 +63,18 @@ var DefaultConfig = Config{
 		Percentile: 60,
 	},
 	Rollup: rollup.Config{
-		StateDumpPath:   "https://raw.githubusercontent.com/ethereum-optimism/regenesis/master/master.json",
-		MaxCallDataSize: 512,
+		StateDumpPath: "https://raw.githubusercontent.com/ethereum-optimism/regenesis/master/master.json",
+		// The max consensus size of a transaction is 24000 bytes. The overhead
+		// for submitting a batch is as follows:
+		// 4 bytes function selector
+		// 5 bytes shouldStartAtElement
+		// 3 bytes totalElementsToAppend
+		// 3 bytes context header
+		// 16 bytes for a single batch context
+		// 3 bytes for tx size
+		// the rest of the data can be used for the transaction
+		//  24000-(5+3+3+16+4+3) = 23966
+		MaxCallDataSize: 23966,
 	},
 	DiffDbCache: 256,
 }

--- a/eth/config.go
+++ b/eth/config.go
@@ -64,8 +64,9 @@ var DefaultConfig = Config{
 	},
 	Rollup: rollup.Config{
 		StateDumpPath: "https://raw.githubusercontent.com/ethereum-optimism/regenesis/master/master.json",
-		// The max consensus size of a transaction is 24000 bytes. The overhead
-		// for submitting a batch is as follows:
+		// The max size of a transaction that is sent over the p2p network is 128kb
+		// https://github.com/ethereum/go-ethereum/blob/c2d2f4ed8f232bb11663a1b01a2e578aa22f24bd/core/tx_pool.go#L51
+		// The batch overhead is:
 		// 4 bytes function selector
 		// 5 bytes shouldStartAtElement
 		// 3 bytes totalElementsToAppend
@@ -73,8 +74,11 @@ var DefaultConfig = Config{
 		// 16 bytes for a single batch context
 		// 3 bytes for tx size
 		// the rest of the data can be used for the transaction
-		//  24000-(5+3+3+16+4+3) = 23966
-		MaxCallDataSize: 23966,
+		// Therefore, the max safe tx size to accept via the sequencer is:
+		// 128000 - (5+3+3+16+4+3) = 127966
+		// The mempool would need to be bypassed if a transaction any larger was
+		// accepted.
+		MaxCallDataSize: 127966,
 	},
 	DiffDbCache: 256,
 }

--- a/eth/config.go
+++ b/eth/config.go
@@ -77,8 +77,10 @@ var DefaultConfig = Config{
 		// Therefore, the max safe tx size to accept via the sequencer is:
 		// 128000 - (5+3+3+16+4+3) = 127966
 		// The mempool would need to be bypassed if a transaction any larger was
-		// accepted.
-		MaxCallDataSize: 127966,
+		// accepted. This option applies to the transaction calldata, so there
+		// is additional overhead that is unaccounted. Round down to 127000 for
+		// safety.
+		MaxCallDataSize: 127000,
 	},
 	DiffDbCache: 256,
 }


### PR DESCRIPTION
## Description

Calculates the max amount of calldata size that a queue origin sequencer transaction can be so that it is impossible to submit a transaction that cannot be batch submitted to layer one and uses that as the default config option. Note that we currently have a smaller value running so this makes the network more permissive

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.