### PR TITLE
fix: Correct address from which events are emitted

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -662,12 +662,7 @@ func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *big.I
 			return nil, caller.Address(), 0, ErrOvmCreationFailed
 		}
 
-		// ovmADDRESS will be set by the execution manager to the target address whenever it's
-		// about to create a new contract. This value is currently stored at the [15] storage slot.
-		// Can pull this specific storage slot to get the address that the execution manager is
-		// trying to create to, and create to it.
-		slot := common.Hash{31: 0x0f}
-		contractAddr = common.BytesToAddress(evm.StateDB.GetState(evm.Context.OvmExecutionManager.Address, slot).Bytes())
+		contractAddr = evm.OvmADDRESS()
 
 		if evm.Context.EthCallSender == nil {
 			log.Debug("[EM] Creating contract.", "ID", evm.Id, "New contract address", contractAddr.Hex(), "Caller Addr", caller.Address().Hex(), "Caller nonce", evm.StateDB.GetNonce(caller.Address()))
@@ -693,9 +688,7 @@ func (evm *EVM) Create2(caller ContractRef, code []byte, gas uint64, endowment *
 			return nil, caller.Address(), 0, ErrOvmCreationFailed
 		}
 
-		// Same logic here as in Create, as seen above.
-		slot := common.Hash{31: 0x0f}
-		contractAddr = common.BytesToAddress(evm.StateDB.GetState(evm.Context.OvmExecutionManager.Address, slot).Bytes())
+		contractAddr = evm.OvmADDRESS()
 
 		if evm.Context.EthCallSender == nil {
 			log.Debug("[EM] Creating contract [create2].", "ID", evm.Id, "New contract address", contractAddr.Hex(), "Caller Addr", caller.Address().Hex(), "Caller nonce", evm.StateDB.GetNonce(caller.Address()))
@@ -707,3 +700,12 @@ func (evm *EVM) Create2(caller ContractRef, code []byte, gas uint64, endowment *
 
 // ChainConfig returns the environment's chain configuration
 func (evm *EVM) ChainConfig() *params.ChainConfig { return evm.chainConfig }
+
+// OvmADDRESS will be set by the execution manager to the target address whenever it's
+// about to create a new contract. This value is currently stored at the [15] storage slot.
+// Can pull this specific storage slot to get the address that the execution manager is
+// trying to create to, and create to it.
+func (evm *EVM) OvmADDRESS() common.Address {
+	slot := common.Hash{31: 0x0f}
+	return common.BytesToAddress(evm.StateDB.GetState(evm.Context.OvmExecutionManager.Address, slot).Bytes())
+}

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -895,7 +895,7 @@ func makeLog(size int) executionFunc {
 
 		d := memory.GetCopy(mStart.Int64(), mSize.Int64())
 		interpreter.evm.StateDB.AddLog(&types.Log{
-			Address: contract.Address(),
+			Address: interpreter.evm.OvmADDRESS(),
 			Topics:  topics,
 			Data:    d,
 			// This is a non-consensus field, but assigned here because

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -893,9 +893,14 @@ func makeLog(size int) executionFunc {
 			topics[i] = common.BigToHash(stack.pop())
 		}
 
+		contractAddr := contract.Address()
+		if UsingOVM {
+			contractAddr = interpreter.evm.OvmADDRESS()
+		}
+
 		d := memory.GetCopy(mStart.Int64(), mSize.Int64())
 		interpreter.evm.StateDB.AddLog(&types.Log{
-			Address: interpreter.evm.OvmADDRESS(),
+			Address: contractAddr,
 			Topics:  topics,
 			Data:    d,
 			// This is a non-consensus field, but assigned here because


### PR DESCRIPTION
## Description
Should fix #252. Issue was that the address being attached to the event was the EVM's current address and not the OVM's current address. Event address now comes directly from the execution manager.

## Metadata
### Fixes
- Fixes #252 

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.