### PR TITLE
Sequencer Fee Pricing Part 3, feat: Pull L1Gasprice from the Data Service

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -234,7 +234,10 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	}
 	eth.APIBackend.gpo = gasprice.NewOracle(eth.APIBackend, gpoParams)
 
-	eth.APIBackend.l1gpo = gasprice.NewL1Oracle(config.Rollup.L1GasPrice)
+	// create the L1 GPO and allow the API backend and the sync service to access it
+	l1Gpo := gasprice.NewL1Oracle(config.Rollup.L1GasPrice)
+	eth.APIBackend.l1gpo = l1Gpo
+	eth.syncService.l1gpo = l1Gpo
 	return eth, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/huin/goupnp v1.0.0
 	github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883
 	github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458
+	github.com/jarcoal/httpmock v1.0.8
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/julienschmidt/httprouter v1.1.1-0.20170430222011-975b5c4c7c21
 	github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883 h1:FSeK4fZCo
 github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458 h1:6OvNmYgJyexcZ3pYbTI9jWx5tHo1Dee/tWbLMfPe2TA=
 github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
+github.com/jarcoal/httpmock v1.0.8 h1:8kI16SoO6LQKgPE7PvQuV+YuD/inwHd7fOOe2zMbo4k=
+github.com/jarcoal/httpmock v1.0.8/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmoiron/sqlx v1.2.0 h1:41Ip0zITnmWNR/vHV+S4m+VoUivnWY5E4OJfLZjCJMA=

--- a/rollup/client.go
+++ b/rollup/client.go
@@ -43,7 +43,7 @@ type SyncStatus struct {
 }
 
 type L1GasPrice struct {
-	GasPrice hexutil.Big `json:"gasPrice"`
+	GasPrice string `json:"gasPrice"`
 }
 
 type transaction struct {
@@ -459,5 +459,10 @@ func (c *Client) GetL1GasPrice() (*big.Int, error) {
 		return nil, fmt.Errorf("Cannot parse L1 gas price response")
 	}
 
-	return (*big.Int)(&gasPriceResp.GasPrice), nil
+	gasPrice, ok := new(big.Int).SetString(gasPriceResp.GasPrice, 10)
+	if !ok {
+		return nil, fmt.Errorf("Cannot parse response as big number")
+	}
+
+	return gasPrice, nil
 }

--- a/rollup/client.go
+++ b/rollup/client.go
@@ -42,6 +42,10 @@ type SyncStatus struct {
 	CurrentTransactionIndex      uint64 `json:"currentTransactionIndex"`
 }
 
+type L1GasPrice struct {
+	GasPrice hexutil.Big `json:"gasPrice"`
+}
+
 type transaction struct {
 	Index       uint64          `json:"index"`
 	BatchIndex  uint64          `json:"batchIndex"`
@@ -92,6 +96,7 @@ type RollupClient interface {
 	GetLatestEthContext() (*EthContext, error)
 	GetLastConfirmedEnqueue() (*types.Transaction, error)
 	SyncStatus() (*SyncStatus, error)
+	GetL1GasPrice() (*big.Int, error)
 }
 
 type Client struct {
@@ -438,4 +443,21 @@ func (c *Client) SyncStatus() (*SyncStatus, error) {
 	}
 
 	return status, nil
+}
+
+func (c *Client) GetL1GasPrice() (*big.Int, error) {
+	response, err := c.client.R().
+		SetResult(&L1GasPrice{}).
+		Get("/eth/gasprice")
+
+	if err != nil {
+		return nil, fmt.Errorf("Cannot fetch L1 gas price: %w", err)
+	}
+
+	gasPriceResp, ok := response.Result().(*L1GasPrice)
+	if !ok {
+		return nil, fmt.Errorf("Cannot parse L1 gas price response")
+	}
+
+	return (*big.Int)(&gasPriceResp.GasPrice), nil
 }

--- a/rollup/client_test.go
+++ b/rollup/client_test.go
@@ -1,0 +1,42 @@
+package rollup
+
+import (
+	"fmt"
+	"github.com/jarcoal/httpmock"
+	"math/big"
+	"testing"
+)
+
+func TestRollupClientGetL1GasPrice(t *testing.T) {
+	url := "http://localhost:9999"
+	endpoint := fmt.Sprintf("%s/eth/gasprice", url)
+	// url/chain-id does not matter, we'll mock the responses
+	client := NewClient(url, big.NewInt(1))
+	// activate the mock
+	httpmock.ActivateNonDefault(client.client.GetClient())
+
+	// The API responds with a string value
+	expectedGasPrice, _ := new(big.Int).SetString("123132132151245817421893", 10)
+	body := map[string]interface{}{
+		"gasPrice": expectedGasPrice.String(),
+	}
+	response, _ := httpmock.NewJsonResponder(
+		200,
+		body,
+	)
+	httpmock.RegisterResponder(
+		"GET",
+		endpoint,
+		response,
+	)
+
+	gasPrice, err := client.GetL1GasPrice()
+
+	if err != nil {
+		t.Fatal("could not get mocked gas price", err)
+	}
+
+	if gasPrice.Cmp(expectedGasPrice) != 0 {
+		t.Fatal("gasPrice is not parsed properly in the client")
+	}
+}

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -338,114 +338,114 @@ func (s *SyncService) SequencerLoop() {
 	log.Info("Starting Sequencer Loop", "poll-interval", s.pollInterval, "timestamp-refresh-threshold", s.timestampRefreshThreshold)
 	for {
 		s.txLock.Lock()
-        err := s.sequence()
-        if err != nil {
+		err := s.sequence()
+		if err != nil {
 			log.Error("Could not sequence", "error", err)
-            continue
-        }
+			continue
+		}
 		s.txLock.Unlock()
-        time.Sleep(s.pollInterval)
-    }
+		time.Sleep(s.pollInterval)
+	}
 }
 
 func (s *SyncService) sequence() error {
-		// Update to the latest L1 gas price
-		l1GasPrice, err := s.client.GetL1GasPrice()
+	// Update to the latest L1 gas price
+	l1GasPrice, err := s.client.GetL1GasPrice()
+	if err != nil {
+		return err
+	}
+	s.l1gpo.SetL1GasPrice(l1GasPrice)
+
+	// Only the sequencer needs to poll for enqueue transactions
+	// and then can choose when to apply them. We choose to apply
+	// transactions such that it makes for efficient batch submitting.
+	// Place as many L1ToL2 transactions in the same context as possible
+	// by executing them one after another.
+	latest, err := s.client.GetLatestEnqueue()
+	if err != nil {
+		return err
+	}
+
+	// This should never happen unless the backend is empty
+	if latest == nil {
+		return errors.New("No enqueue transactions found")
+	}
+
+	// Compare the remote latest queue index to the local latest
+	// queue index. If the remote latest queue index is greater
+	// than the local latest queue index, be sure to ingest more
+	// enqueued transactions
+	var start uint64
+	if s.GetLatestEnqueueIndex() == nil {
+		start = 0
+	} else {
+		start = *s.GetLatestEnqueueIndex() + 1
+	}
+	end := *latest.GetMeta().QueueIndex
+
+	log.Info("Polling enqueued transactions", "start", start, "end", end)
+	for i := start; i <= end; i++ {
+		enqueue, err := s.client.GetEnqueue(i)
 		if err != nil {
-            return err
+			log.Error("Cannot get enqueue in loop", "index", i, "message", err)
+			continue
 		}
-		s.l1gpo.SetL1GasPrice(l1GasPrice)
 
-		// Only the sequencer needs to poll for enqueue transactions
-		// and then can choose when to apply them. We choose to apply
-		// transactions such that it makes for efficient batch submitting.
-		// Place as many L1ToL2 transactions in the same context as possible
-		// by executing them one after another.
-		latest, err := s.client.GetLatestEnqueue()
+		if enqueue == nil {
+			log.Debug("No enqueue transaction found")
+			break
+		}
+
+		// This should never happen
+		if enqueue.L1BlockNumber() == nil {
+			log.Error("No blocknumber for enqueue", "index", i, "timestamp", enqueue.L1Timestamp(), "blocknumber", enqueue.L1BlockNumber())
+			continue
+		}
+
+		// Update the timestamp and blocknumber based on the enqueued
+		// transactions
+		if enqueue.L1Timestamp() > s.GetLatestL1Timestamp() {
+			ts := enqueue.L1Timestamp()
+			bn := enqueue.L1BlockNumber().Uint64()
+			s.SetLatestL1Timestamp(ts)
+			s.SetLatestL1BlockNumber(bn)
+			log.Info("Updated Eth Context from enqueue", "index", i, "timestamp", ts, "blocknumber", bn)
+		}
+
+		log.Debug("Applying enqueue transaction", "index", i)
+		err = s.applyTransaction(enqueue)
 		if err != nil {
-            return err
+			log.Error("Cannot apply transaction", "msg", err)
 		}
 
-		// This should never happen unless the backend is empty
-		if latest == nil {
-            return errors.New("No enqueue transactions found")
-		}
-
-		// Compare the remote latest queue index to the local latest
-		// queue index. If the remote latest queue index is greater
-		// than the local latest queue index, be sure to ingest more
-		// enqueued transactions
-		var start uint64
-		if s.GetLatestEnqueueIndex() == nil {
-			start = 0
+		s.SetLatestEnqueueIndex(enqueue.GetMeta().QueueIndex)
+		if enqueue.GetMeta().Index == nil {
+			latest := s.GetLatestIndex()
+			index := uint64(0)
+			if latest != nil {
+				index = *latest + 1
+			}
+			s.SetLatestIndex(&index)
 		} else {
-			start = *s.GetLatestEnqueueIndex() + 1
+			s.SetLatestIndex(enqueue.GetMeta().Index)
 		}
-		end := *latest.GetMeta().QueueIndex
+	}
 
-		log.Info("Polling enqueued transactions", "start", start, "end", end)
-		for i := start; i <= end; i++ {
-			enqueue, err := s.client.GetEnqueue(i)
-			if err != nil {
-				log.Error("Cannot get enqueue in loop", "index", i, "message", err)
-				continue
-			}
+	// Update the execution context's timestamp and blocknumber
+	// over time. This is only necessary for the sequencer.
+	context, err := s.client.GetLatestEthContext()
+	if err != nil {
+		return err
+	}
+	current := time.Unix(int64(s.GetLatestL1Timestamp()), 0)
+	next := time.Unix(int64(context.Timestamp), 0)
+	if next.Sub(current) > s.timestampRefreshThreshold {
+		log.Info("Updating Eth Context", "timetamp", context.Timestamp, "blocknumber", context.BlockNumber)
+		s.SetLatestL1BlockNumber(context.BlockNumber)
+		s.SetLatestL1Timestamp(context.Timestamp)
+	}
 
-			if enqueue == nil {
-				log.Debug("No enqueue transaction found")
-				break
-			}
-
-			// This should never happen
-			if enqueue.L1BlockNumber() == nil {
-				log.Error("No blocknumber for enqueue", "index", i, "timestamp", enqueue.L1Timestamp(), "blocknumber", enqueue.L1BlockNumber())
-				continue
-			}
-
-			// Update the timestamp and blocknumber based on the enqueued
-			// transactions
-			if enqueue.L1Timestamp() > s.GetLatestL1Timestamp() {
-				ts := enqueue.L1Timestamp()
-				bn := enqueue.L1BlockNumber().Uint64()
-				s.SetLatestL1Timestamp(ts)
-				s.SetLatestL1BlockNumber(bn)
-				log.Info("Updated Eth Context from enqueue", "index", i, "timestamp", ts, "blocknumber", bn)
-			}
-
-			log.Debug("Applying enqueue transaction", "index", i)
-			err = s.applyTransaction(enqueue)
-			if err != nil {
-				log.Error("Cannot apply transaction", "msg", err)
-			}
-
-			s.SetLatestEnqueueIndex(enqueue.GetMeta().QueueIndex)
-			if enqueue.GetMeta().Index == nil {
-				latest := s.GetLatestIndex()
-				index := uint64(0)
-				if latest != nil {
-					index = *latest + 1
-				}
-				s.SetLatestIndex(&index)
-			} else {
-				s.SetLatestIndex(enqueue.GetMeta().Index)
-			}
-		}
-
-		// Update the execution context's timestamp and blocknumber
-		// over time. This is only necessary for the sequencer.
-		context, err := s.client.GetLatestEthContext()
-		if err != nil {
-            return err
-		}
-		current := time.Unix(int64(s.GetLatestL1Timestamp()), 0)
-		next := time.Unix(int64(context.Timestamp), 0)
-		if next.Sub(current) > s.timestampRefreshThreshold {
-			log.Info("Updating Eth Context", "timetamp", context.Timestamp, "blocknumber", context.BlockNumber)
-			s.SetLatestL1BlockNumber(context.BlockNumber)
-			s.SetLatestL1Timestamp(context.Timestamp)
-		}
-        
-        return nil
+	return nil
 }
 
 // This function must sync all the way to the tip

--- a/rollup/sync_service_test.go
+++ b/rollup/sync_service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/eth/gasprice"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
 )
@@ -240,6 +241,7 @@ type mockClient struct {
 func setupMockClient(service *SyncService, responses map[string]interface{}) {
 	client := newMockClient(responses)
 	service.client = client
+	service.l1gpo = gasprice.NewL1Oracle(big.NewInt(0))
 }
 
 func newMockClient(responses map[string]interface{}) *mockClient {
@@ -319,4 +321,8 @@ func (m *mockClient) SyncStatus() (*SyncStatus, error) {
 	return &SyncStatus{
 		Syncing: false,
 	}, nil
+}
+
+func (m *mockClient) GetL1GasPrice() (*big.Int, error) {
+	return big.NewInt(100 * int64(params.GWei)), nil
 }

--- a/rollup/sync_service_test.go
+++ b/rollup/sync_service_test.go
@@ -79,6 +79,37 @@ func TestSyncServiceTransactionEnqueued(t *testing.T) {
 	}
 }
 
+func TestSyncServiceL1GasPrice(t *testing.T) {
+	service, _, _, err := newTestSyncService(true)
+	setupMockClient(service, map[string]interface{}{})
+	service.l1gpo = gasprice.NewL1Oracle(big.NewInt(0))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gasBefore, err := service.l1gpo.SuggestDataPrice(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if gasBefore.Cmp(big.NewInt(0)) != 0 {
+		t.Fatal("expected 0 gas price, got", gasBefore)
+	}
+
+	// run 1 iteration of the eloop
+	service.sequence()
+
+	gasAfter, err := service.l1gpo.SuggestDataPrice(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if gasAfter.Cmp(big.NewInt(100*int64(params.GWei))) != 0 {
+		t.Fatal("expected 100 gas price, got", gasAfter)
+	}
+}
+
 // Pass true to set as a verifier
 func TestSyncServiceSync(t *testing.T) {
 	t.Skip("TODO unstick this")


### PR DESCRIPTION
As @tynes recommended, this PR fetches the gas price from the data service and sets it in the gas price oracle. I also have [refactored the sequencer loop](https://github.com/ethereum-optimism/go-ethereum/commit/94e6a3f30f2a65e2cf5c4e0fc65e9ea3d47c1558) so that we can test 1 iteration of it, cleaning up the mutexes/logs in it.