### PR TITLE
blocknumber: fix

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -97,6 +97,9 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 	}
 	// Create a new context to be used in the EVM environment
 	context := NewEVMContext(msg, header, bc, author)
+	if vm.UsingOVM {
+		context.BlockNumber = msg.L1BlockNumber()
+	}
 	// Create a new environment which holds all relevant information
 	// about the transaction and calling mechanisms.
 	vmenv := vm.NewEVM(context, statedb, config, cfg)

--- a/core/state_transition_ovm.go
+++ b/core/state_transition_ovm.go
@@ -13,19 +13,19 @@ import (
 var ZeroAddress = common.HexToAddress("0x0000000000000000000000000000000000000000")
 
 type ovmTransaction struct {
-	Timestamp     *big.Int       "json:\"timestamp\""
-	BlockNumber   *big.Int       "json:\"blockNumber\""
-	L1QueueOrigin uint8          "json:\"l1QueueOrigin\""
-	L1TxOrigin    common.Address "json:\"l1TxOrigin\""
-	Entrypoint    common.Address "json:\"entrypoint\""
-	GasLimit      *big.Int       "json:\"gasLimit\""
-	Data          []uint8        "json:\"data\""
+	Timestamp     *big.Int       `json:"timestamp"`
+	BlockNumber   *big.Int       `json:"blockNumber"`
+	L1QueueOrigin uint8          `json:"l1QueueOrigin"`
+	L1TxOrigin    common.Address `json:"l1TxOrigin"`
+	Entrypoint    common.Address `json:"entrypoint"`
+	GasLimit      *big.Int       `json:"gasLimit"`
+	Data          []uint8        `json:"data"`
 }
 
 func toExecutionManagerRun(evm *vm.EVM, msg Message) (Message, error) {
 	tx := ovmTransaction{
 		evm.Context.Time,
-		evm.Context.BlockNumber, // TODO (what's the correct block number?)
+		msg.L1BlockNumber(),
 		uint8(msg.QueueOrigin().Uint64()),
 		*msg.L1MessageSender(),
 		*msg.To(),


### PR DESCRIPTION
## Description

The blocknumber in the EVM is currently non deterministic between the fraud proofs. This ensures that the same value is passed to both `ExecutionManager.run` and the geth EVM

This needs to be tested

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.