### PR TITLE
Refactor Sync Service Sequencer/Verifier loops

### DIFF
--- a/rollup/client.go
+++ b/rollup/client.go
@@ -332,7 +332,7 @@ func (c *Client) GetTransaction(index uint64) (*types.Transaction, error) {
 	}
 	res, ok := response.Result().(*TransactionResponse)
 	if !ok {
-		return nil, errors.New("")
+		return nil, fmt.Errorf("could not get tx with index %d", index)
 	}
 
 	return transactionResponseToTransaction(res, c.signer)

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -309,7 +309,8 @@ func (s *SyncService) verify() error {
 	}
 
 	if latest == nil {
-		return errors.New("latest transaction not found")
+		log.Debug("latest transaction not found")
+		return nil
 	}
 
 	var start uint64
@@ -369,7 +370,8 @@ func (s *SyncService) sequence() error {
 
 	// This should never happen unless the backend is empty
 	if latest == nil {
-		return errors.New("No enqueue transactions found")
+		log.Debug("No enqueue transactions found")
+		return nil
 	}
 
 	// Compare the remote latest queue index to the local latest

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -393,7 +393,8 @@ func (s *SyncService) sequence() error {
 		}
 
 		if enqueue == nil {
-			return errors.New("No enqueue transaction found")
+			log.Debug("No enqueue transaction found")
+			return nil
 		}
 
 		// This should never happen

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -347,6 +347,11 @@ func (s *SyncService) SequencerLoop() {
 			log.Error("Could not sequence", "error", err)
 		}
 		s.txLock.Unlock()
+
+		if s.updateContext() != nil {
+			log.Error("Could not update execution context", "error", err)
+		}
+
 		time.Sleep(s.pollInterval)
 	}
 }
@@ -427,8 +432,12 @@ func (s *SyncService) sequence() error {
 		}
 	}
 
-	// Update the execution context's timestamp and blocknumber
-	// over time. This is only necessary for the sequencer.
+	return nil
+}
+
+/// Update the execution context's timestamp and blocknumber
+/// over time. This is only necessary for the sequencer.
+func (s *SyncService) updateContext() error {
 	context, err := s.client.GetLatestEthContext()
 	if err != nil {
 		return err

--- a/rollup/sync_service_test.go
+++ b/rollup/sync_service_test.go
@@ -36,6 +36,16 @@ func setupLatestEthContextTest() (*SyncService, *EthContext) {
 func TestSyncServiceContextUpdated(t *testing.T) {
 	service, resp := setupLatestEthContextTest()
 
+	// should get the expected context
+	expectedCtx := &OVMContext{
+		blockNumber: 0,
+		timestamp:   0,
+	}
+
+	if service.OVMContext != *expectedCtx {
+		t.Fatal("context was not instantiated to the expected value")
+	}
+
 	// run the update context call once
 	err := service.updateContext()
 	if err != nil {
@@ -43,7 +53,7 @@ func TestSyncServiceContextUpdated(t *testing.T) {
 	}
 
 	// should get the expected context
-	expectedCtx := &OVMContext{
+	expectedCtx = &OVMContext{
 		blockNumber: resp.BlockNumber,
 		timestamp:   resp.Timestamp,
 	}

--- a/rollup/sync_service_test.go
+++ b/rollup/sync_service_test.go
@@ -98,9 +98,9 @@ func TestSyncServiceTransactionEnqueued(t *testing.T) {
 	// The L1 blocknumber for the transaction's evm context
 	l1BlockNumber := big.NewInt(100)
 	// The queue index of the L1 to L2 transaction
-	queueIndex := uint64(100)
-	//The index in the ctc
-	index := uint64(120)
+	queueIndex := uint64(0)
+	// The index in the ctc
+	index := uint64(5)
 
 	tx := types.NewTransaction(0, target, big.NewInt(0), gasLimit, big.NewInt(0), data)
 	txMeta := types.NewTransactionMeta(

--- a/rollup/sync_service_test.go
+++ b/rollup/sync_service_test.go
@@ -63,8 +63,12 @@ func TestSyncServiceTransactionEnqueued(t *testing.T) {
 		},
 	})
 
-	// Start up the main loop
-	go service.SequencerLoop()
+	// Run an iteration of the eloop
+	err = service.sequence()
+	if err != nil {
+		t.Fatal("sequencing failed", err)
+	}
+
 	// Wait for the tx to be confirmed into the chain and then
 	// make sure it is the transactions that was set up with in the mockclient
 	event := <-txCh

--- a/rollup/sync_service_test.go
+++ b/rollup/sync_service_test.go
@@ -84,8 +84,6 @@ func TestSyncServiceTransactionEnqueued(t *testing.T) {
 
 // Pass true to set as a verifier
 func TestSyncServiceSync(t *testing.T) {
-	t.Skip("TODO unstick this")
-
 	service, txCh, sub, err := newTestSyncService(true)
 	defer sub.Unsubscribe()
 	if err != nil {
@@ -119,7 +117,10 @@ func TestSyncServiceSync(t *testing.T) {
 		},
 	})
 
-	go service.VerifierLoop()
+	err = service.verify()
+	if err != nil {
+		t.Fatal("verification failed", err)
+	}
 
 	event := <-txCh
 	if len(event.Txs) != 1 {


### PR DESCRIPTION
## Description

Previously, the sequencer/verifier functionality was tied to an infinite loop, making the individual functionality hard to test, while also requiring managing poll sleep timers and locks inside each function. 

This PR refactors these functionalities so that the mutex/sleeping happens at the outer functions which perform the loop, while the internal functions are focused on doing 1 iteration. 

It also re-enables a previously disabled sync service test.