### PR TITLE
refactor: Rename data-transport-layer to transaction-indexer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v0.1.3
 
-- Integrate data transport layer
+
+- Integrate data transport layer <!-- Addendum 2021-03-30: "data transport layer" was renamed to "transaction-indexer" -->
 - Refactor `SyncService`
 - New RPC Endpoint `eth_getBlockRange`
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ $ make geth
 
 ### Running a Sequencer
 
-Running a sequencer requires the [Data Transport Layer](https://github.com/ethereum-optimism/data-transport-layer)
-to be synced. The data transport layer is responsible for indexing transactions
-from Layer One concurrently. The sequencer pulls in transactions from the data
-transport layer and executes them. The URL of the data transport layer should be
-used for the sequencer config option `--rollup.clienthttp`.
+Running a sequencer requires the [`transaction-indexer`](https://github.com/ethereum-optimism/transaction-indexer)
+to be synced. The `transaction-indexer` is responsible for indexing transactions
+from Layer One concurrently. The sequencer pulls in transactions from the
+`transaction-indexer` and executes them. The URL of the `transaction-indexer` 
+should be used for the sequencer config option `--rollup.clienthttp`.
 
 See the script `scripts/start.sh`. It sets many of the config options
 and accepts CLI flags. For usage, run the command:

--- a/rollup/config.go
+++ b/rollup/config.go
@@ -20,7 +20,7 @@ type Config struct {
 	Eth1ChainId uint64
 	// Gas Limit
 	GasLimit uint64
-	// HTTP endpoint of the data transport layer
+	// HTTP endpoint of the transaction-indexer
 	RollupClientHttp              string
 	L1CrossDomainMessengerAddress common.Address
 	AddressManagerOwnerAddress    common.Address


### PR DESCRIPTION
**Description**
We're renaming the `data-transport-layer` to the `transaction-indexer`. The name "`data-transport-layer`" is too vague so we're changing it while we still can. This is a multi-repo change that involves:

- `data-transport-layer`
- `go-ethereum`
- `docker`
- `optimism-integration`