### PR TITLE
fix: Have OVM provide all available gas to txs

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -90,7 +90,7 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *commo
 		}
 	} else {
 		decompressor := config.StateDump.Accounts["OVM_SequencerEntrypoint"]
-		msg, err = AsOvmMessage(tx, types.MakeSigner(config, header.Number), decompressor.Address)
+		msg, err = AsOvmMessage(tx, types.MakeSigner(config, header.Number), decompressor.Address, header.GasLimit)
 		if err != nil {
 			return nil, err
 		}

--- a/core/state_transition_ovm.go
+++ b/core/state_transition_ovm.go
@@ -58,7 +58,7 @@ func toExecutionManagerRun(evm *vm.EVM, msg Message) (Message, error) {
 	return outputmsg, nil
 }
 
-func AsOvmMessage(tx *types.Transaction, signer types.Signer, decompressor common.Address) (Message, error) {
+func AsOvmMessage(tx *types.Transaction, signer types.Signer, decompressor common.Address, gasLimit uint64) (Message, error) {
 	msg, err := tx.AsMessage(signer)
 	if err != nil {
 		// This should only be allowed to pass if the transaction is in the ctc
@@ -85,7 +85,7 @@ func AsOvmMessage(tx *types.Transaction, signer types.Signer, decompressor commo
 		msg.From(),
 		&decompressor,
 		tx.GetMeta().RawTransaction,
-		msg.Gas(),
+		gasLimit,
 	)
 
 	if err != nil {

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -809,7 +809,7 @@ func (api *PrivateDebugAPI) computeTxEnv(blockHash common.Hash, txIndex int, ree
 		if !vm.UsingOVM {
 			msg, _ = tx.AsMessage(signer)
 		} else {
-			msg, err = core.AsOvmMessage(tx, signer, common.HexToAddress("0x4200000000000000000000000000000000000005"))
+			msg, err = core.AsOvmMessage(tx, signer, common.HexToAddress("0x4200000000000000000000000000000000000005"), block.Header().GasLimit)
 			if err != nil {
 				return nil, vm.Context{}, nil, err
 			}


### PR DESCRIPTION
## Description
Small-but-significant change that forces the OVM to provide *all* available gas to every transaction instead of just the gas that the user has specified.

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.