### PR TITLE
monotonicity: prevent race condition

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -872,6 +872,11 @@ func (w *worker) commitNewTx(tx *types.Transaction) error {
 		log.Error("Monotonicity violation", "index", num)
 		if tx.QueueOrigin().Uint64() == uint64(types.QueueOriginSequencer) {
 			tx.SetL1Timestamp(parent.Time())
+			prev := parent.Transactions()
+			if len(prev) != 1 {
+				panic("Cannot recover L1BlockNumber")
+			}
+			tx.SetL1BlockNumber(prev[0].L1BlockNumber().Uint64())
 		} else {
 			panic("Monotonicity violation")
 		}

--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -660,6 +660,13 @@ func (s *SyncService) ApplyTransaction(tx *types.Transaction) error {
 		return fmt.Errorf("invalid transaction: %w", err)
 	}
 
+	if tx.L1Timestamp() == 0 {
+		ts := s.GetLatestL1Timestamp()
+		bn := s.GetLatestL1BlockNumber()
+		tx.SetL1Timestamp(ts)
+		tx.SetL1BlockNumber(bn)
+	}
+
 	// Set the raw transaction data in the meta
 	txRaw, err := getRawTransaction(tx)
 	if err != nil {


### PR DESCRIPTION
## Description
Adds a fix for the race condition that would allow for a monotonicity violation. This is important to maintain liveliness while keeping the verifier and sequencer state in sync

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.