### PR TITLE
rollup: check for nil tx before applying

### DIFF
--- a/rollup/sync_service.go
+++ b/rollup/sync_service.go
@@ -598,6 +598,10 @@ func (s *SyncService) SubscribeNewTxsEvent(ch chan<- core.NewTxsEvent) event.Sub
 // inspecting the local database. This is mean to prevent transactions from
 // being replayed.
 func (s *SyncService) maybeApplyTransaction(tx *types.Transaction) error {
+	if tx == nil {
+		return fmt.Errorf("nil transaction passed to maybeApplyTransaction")
+	}
+
 	log.Debug("Maybe applying transaction", "hash", tx.Hash().Hex())
 	index := tx.GetMeta().Index
 	if index == nil {
@@ -642,6 +646,10 @@ func (s *SyncService) applyTransaction(tx *types.Transaction) error {
 // queue origin sequencer transactions, as the contracts on L1 manage the same
 // validity checks that are done here.
 func (s *SyncService) ApplyTransaction(tx *types.Transaction) error {
+	if tx == nil {
+		return fmt.Errorf("nil transaction passed to ApplyTransaction")
+	}
+
 	log.Debug("Sending transaction to sync service", "hash", tx.Hash().Hex())
 	s.txLock.Lock()
 	defer s.txLock.Unlock()


### PR DESCRIPTION
## Description

Does a quick check for `nil` transactions before attempting to apply them

## Metadata
### Fixes
- Fixes # [Link to Issue]

## Contributing Agreement
<!--
You *must* read and fully understand our Contributing Guide and Code of Conduct before submitting this pull request. Strong, healthy, and respectful communities are the best way to build great code 💖.
-->

- [x] I have read and understood the [Optimism Contributing Guide and Code of Conduct](./CONTRIBUTING.md) and am following those guidelines in this pull request.